### PR TITLE
Rebuild A2: auth — TOTP MFA + rotating refresh sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@nestjs/testing": "^11.0.0",
         "@types/cookie-parser": "^1.4.8",
         "@types/express": "^5.0.0",
+        "@types/jest": "^30.0.0",
         "@types/multer": "^1.4.12",
         "@types/node": "^22.10.0",
         "@types/pg": "^8.11.10",
@@ -2672,6 +2673,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2733,6 +2744,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2747,6 +2768,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -3668,6 +3713,219 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -9404,6 +9662,22 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@nestjs/testing": "^11.0.0",
     "@types/cookie-parser": "^1.4.8",
     "@types/express": "^5.0.0",
+    "@types/jest": "^30.0.0",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.10.0",
     "@types/pg": "^8.11.10",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { DbModule } from './db/db.module';
+import { AuthModule } from './modules/auth/auth.module';
 import { HealthModule } from './modules/health/health.module';
 
 @Module({
@@ -10,6 +11,7 @@ import { HealthModule } from './modules/health/health.module';
     ConfigModule.forRoot({ isGlobal: true }),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 120 }]),
     DbModule,
+    AuthModule,
     HealthModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/src/app.setup.ts
+++ b/src/app.setup.ts
@@ -1,0 +1,19 @@
+import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import cookieParser from 'cookie-parser';
+import helmet from 'helmet';
+import { requireEnv } from './common/env';
+
+/** Shared between main.ts and the e2e test harness so both run the same app. */
+export function configureApp(app: NestExpressApplication): void {
+  app.setGlobalPrefix('api');
+  app.use(helmet());
+  app.use(cookieParser());
+  app.useBodyParser('json', { limit: '2mb' });
+  app.enableCors({
+    origin: requireEnv('CORS_ORIGINS').split(','),
+    credentials: true,
+  });
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.disable('x-powered-by');
+}

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { AuthenticatedRequest } from '../guards/access-token.guard';
+
+export const CurrentUserId = createParamDecorator((_data: unknown, context: ExecutionContext) => {
+  const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+  return request.userId;
+});

--- a/src/common/duration.ts
+++ b/src/common/duration.ts
@@ -1,0 +1,12 @@
+/** Parse durations like '15m', '12h', '7d' into milliseconds. Throws on anything else. */
+export function durationToMs(value: string): number {
+  const match = /^(\d+)([smhd])$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid duration: '${value}' (expected e.g. '30s', '15m', '12h', '7d')`);
+  }
+  const amount = Number(match[1]);
+  const unit = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 }[
+    match[2] as 's' | 'm' | 'h' | 'd'
+  ];
+  return amount * unit;
+}

--- a/src/common/guards/access-token.guard.ts
+++ b/src/common/guards/access-token.guard.ts
@@ -1,0 +1,33 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+
+export interface AuthenticatedRequest extends Request {
+  userId: string;
+}
+
+@Injectable()
+export class AccessTokenGuard implements CanActivate {
+  constructor(private readonly jwt: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const header = request.headers.authorization;
+    if (!header || !header.startsWith('Bearer ')) {
+      throw new UnauthorizedException();
+    }
+
+    try {
+      const payload = await this.jwt.verifyAsync<{ sub: string; type: string }>(
+        header.slice('Bearer '.length),
+      );
+      if (payload.type !== 'access') {
+        throw new UnauthorizedException();
+      }
+      request.userId = payload.sub;
+      return true;
+    } catch {
+      throw new UnauthorizedException();
+    }
+  }
+}

--- a/src/db/db.module.ts
+++ b/src/db/db.module.ts
@@ -1,26 +1,40 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, Inject, Injectable, Module, OnApplicationShutdown } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import * as schema from './schema';
 
 export const DRIZZLE = Symbol('DRIZZLE');
+const PG_POOL = Symbol('PG_POOL');
 export type Database = NodePgDatabase<typeof schema>;
+
+@Injectable()
+class PoolLifecycle implements OnApplicationShutdown {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  async onApplicationShutdown(): Promise<void> {
+    await this.pool.end();
+  }
+}
 
 @Global()
 @Module({
   providers: [
     {
-      provide: DRIZZLE,
+      provide: PG_POOL,
       inject: [ConfigService],
-      useFactory: (config: ConfigService): Database => {
-        const pool = new Pool({
+      useFactory: (config: ConfigService): Pool =>
+        new Pool({
           connectionString: config.getOrThrow<string>('DATABASE_URL'),
           ssl: config.get('DATABASE_SSL') === 'true' ? { rejectUnauthorized: true } : undefined,
-        });
-        return drizzle(pool, { schema });
-      },
+        }),
     },
+    {
+      provide: DRIZZLE,
+      inject: [PG_POOL],
+      useFactory: (pool: Pool): Database => drizzle(pool, { schema }),
+    },
+    PoolLifecycle,
   ],
   exports: [DRIZZLE],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,29 +1,12 @@
-import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import cookieParser from 'cookie-parser';
-import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { requireEnv } from './common/env';
+import { configureApp } from './app.setup';
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    rawBody: false,
-  });
-
-  app.setGlobalPrefix('api');
-  app.use(helmet());
-  app.use(cookieParser());
-  app.useBodyParser('json', { limit: '2mb' });
-  app.enableCors({
-    origin: requireEnv('CORS_ORIGINS').split(','),
-    credentials: true,
-  });
-  app.useGlobalPipes(
-    new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: false }),
-  );
-  app.disable('x-powered-by');
-
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  configureApp(app);
   await app.listen(Number(requireEnv('API_PORT')));
 }
 

--- a/src/modules/auth/account.controller.ts
+++ b/src/modules/auth/account.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, HttpCode, Put, UseGuards } from '@nestjs/common';
+import { CurrentUserId } from '../../common/decorators/current-user.decorator';
+import { AccessTokenGuard } from '../../common/guards/access-token.guard';
+import { AuthService } from './auth.service';
+import { ChangePasswordDto } from './dto/auth.dto';
+
+@Controller('admin')
+@UseGuards(AccessTokenGuard)
+export class AccountController {
+  constructor(private readonly auth: AuthService) {}
+
+  @Put('password')
+  @HttpCode(204)
+  async changePassword(@CurrentUserId() userId: string, @Body() dto: ChangePasswordDto) {
+    await this.auth.changePassword(userId, dto.currentPassword, dto.newPassword);
+  }
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Get, HttpCode, Post, Req, Res, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { Request, Response } from 'express';
+import { CurrentUserId } from '../../common/decorators/current-user.decorator';
+import { AccessTokenGuard } from '../../common/guards/access-token.guard';
+import { AuthService } from './auth.service';
+import { LoginDto, MfaCodeDto } from './dto/auth.dto';
+import { TempTokenGuard, TempTokenRequest } from './temp-token.guard';
+import { REFRESH_COOKIE } from './tokens.service';
+
+const AUTH_THROTTLE = { default: { limit: 5, ttl: 60_000 } };
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly auth: AuthService) {}
+
+  @Post('login')
+  @HttpCode(200)
+  @Throttle(AUTH_THROTTLE)
+  login(@Body() dto: LoginDto) {
+    return this.auth.login(dto.email, dto.password);
+  }
+
+  @Get('mfa/setup')
+  @UseGuards(TempTokenGuard)
+  mfaSetup(@Req() req: TempTokenRequest) {
+    return this.auth.startMfaEnrollment(req.userId, req.tokenPurpose);
+  }
+
+  @Post('mfa/enable')
+  @HttpCode(200)
+  @Throttle(AUTH_THROTTLE)
+  @UseGuards(TempTokenGuard)
+  mfaEnable(
+    @Req() req: TempTokenRequest,
+    @Body() dto: MfaCodeDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    return this.auth.enableMfa(req.userId, req.tokenPurpose, dto.code, res);
+  }
+
+  @Post('mfa/verify')
+  @HttpCode(200)
+  @Throttle(AUTH_THROTTLE)
+  @UseGuards(TempTokenGuard)
+  mfaVerify(
+    @Req() req: TempTokenRequest,
+    @Body() dto: MfaCodeDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    return this.auth.verifyMfa(req.userId, req.tokenPurpose, dto.code, res);
+  }
+
+  @Post('refresh')
+  @HttpCode(200)
+  refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    return this.auth.refresh(req.cookies[REFRESH_COOKIE], res);
+  }
+
+  @Post('logout')
+  @HttpCode(204)
+  @UseGuards(AccessTokenGuard)
+  async logout(@CurrentUserId() userId: string, @Res({ passthrough: true }) res: Response) {
+    await this.auth.logout(userId, res);
+  }
+}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,0 +1,25 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { AccountController } from './account.controller';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { MfaService } from './mfa.service';
+import { TokensService } from './tokens.service';
+
+@Global()
+@Module({
+  imports: [
+    JwtModule.registerAsync({
+      global: true,
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.getOrThrow<string>('JWT_SECRET'),
+      }),
+    }),
+  ],
+  controllers: [AuthController, AccountController],
+  providers: [AuthService, TokensService, MfaService],
+  exports: [TokensService],
+})
+export class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,0 +1,128 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { compare, hash } from 'bcryptjs';
+import { eq } from 'drizzle-orm';
+import { Response } from 'express';
+import { Database, DRIZZLE } from '../../db/db.module';
+import { users } from '../../db/schema';
+import { MfaService } from './mfa.service';
+import { TempTokenPurpose } from './temp-token.guard';
+import { TokensService } from './tokens.service';
+
+const TEMP_TOKEN_TTL_SECONDS = 300;
+const PASSWORD_HASH_ROUNDS = 12;
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: Database,
+    private readonly jwt: JwtService,
+    private readonly tokens: TokensService,
+    private readonly mfa: MfaService,
+  ) {}
+
+  async login(email: string, password: string) {
+    const [user] = await this.db.select().from(users).where(eq(users.email, email));
+    if (!user || !(await compare(password, user.passwordHash))) {
+      throw new UnauthorizedException();
+    }
+
+    const purpose: TempTokenPurpose = user.mfaEnabled ? 'mfa' : 'mfa-setup';
+    const tempToken = await this.jwt.signAsync(
+      { sub: user.id, type: purpose },
+      { expiresIn: TEMP_TOKEN_TTL_SECONDS },
+    );
+
+    return user.mfaEnabled
+      ? { mfaRequired: true, tempToken }
+      : { mfaSetupRequired: true, tempToken };
+  }
+
+  async startMfaEnrollment(userId: string, purpose: TempTokenPurpose) {
+    if (purpose !== 'mfa-setup') {
+      throw new ForbiddenException();
+    }
+    const user = await this.getUser(userId);
+    if (user.mfaEnabled) {
+      throw new ConflictException('MFA is already enabled');
+    }
+
+    const secret = this.mfa.generateSecret();
+    await this.db
+      .update(users)
+      .set({ mfaSecret: secret, updatedAt: new Date() })
+      .where(eq(users.id, userId));
+
+    return this.mfa.buildEnrollment(user.email, secret);
+  }
+
+  async enableMfa(userId: string, purpose: TempTokenPurpose, code: string, response: Response) {
+    if (purpose !== 'mfa-setup') {
+      throw new ForbiddenException();
+    }
+    const user = await this.getUser(userId);
+    if (user.mfaEnabled) {
+      throw new ConflictException('MFA is already enabled');
+    }
+    if (!user.mfaSecret || !this.mfa.verify(code, user.mfaSecret)) {
+      throw new UnauthorizedException('Invalid code');
+    }
+
+    await this.db
+      .update(users)
+      .set({ mfaEnabled: true, updatedAt: new Date() })
+      .where(eq(users.id, userId));
+
+    return this.tokens.issueTokens(userId, response);
+  }
+
+  async verifyMfa(userId: string, purpose: TempTokenPurpose, code: string, response: Response) {
+    if (purpose !== 'mfa') {
+      throw new ForbiddenException();
+    }
+    const user = await this.getUser(userId);
+    if (!user.mfaEnabled || !user.mfaSecret || !this.mfa.verify(code, user.mfaSecret)) {
+      throw new UnauthorizedException('Invalid code');
+    }
+
+    return this.tokens.issueTokens(userId, response);
+  }
+
+  async refresh(refreshToken: string | undefined, response: Response) {
+    if (!refreshToken) {
+      throw new UnauthorizedException();
+    }
+    const userId = await this.tokens.verifyRefreshToken(refreshToken);
+    return this.tokens.issueTokens(userId, response);
+  }
+
+  async logout(userId: string, response: Response) {
+    await this.tokens.revokeSession(userId, response);
+  }
+
+  async changePassword(userId: string, currentPassword: string, newPassword: string) {
+    const user = await this.getUser(userId);
+    if (!(await compare(currentPassword, user.passwordHash))) {
+      throw new UnauthorizedException('Current password is incorrect');
+    }
+
+    await this.db
+      .update(users)
+      .set({ passwordHash: await hash(newPassword, PASSWORD_HASH_ROUNDS), updatedAt: new Date() })
+      .where(eq(users.id, userId));
+  }
+
+  private async getUser(userId: string) {
+    const [user] = await this.db.select().from(users).where(eq(users.id, userId));
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return user;
+  }
+}

--- a/src/modules/auth/dto/auth.dto.ts
+++ b/src/modules/auth/dto/auth.dto.ts
@@ -1,0 +1,26 @@
+import { IsEmail, IsNotEmpty, IsString, Length, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}
+
+export class MfaCodeDto {
+  @IsString()
+  @Length(6, 6)
+  code: string;
+}
+
+export class ChangePasswordDto {
+  @IsString()
+  @IsNotEmpty()
+  currentPassword: string;
+
+  @IsString()
+  @MinLength(12)
+  newPassword: string;
+}

--- a/src/modules/auth/mfa.service.ts
+++ b/src/modules/auth/mfa.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { authenticator } from 'otplib';
+import { toDataURL } from 'qrcode';
+
+const ISSUER = 'Personal Blog Admin';
+
+@Injectable()
+export class MfaService {
+  constructor() {
+    // Accept one time-step of clock drift, mirroring the legacy speakeasy setup.
+    authenticator.options = { window: 1 };
+  }
+
+  generateSecret(): string {
+    return authenticator.generateSecret();
+  }
+
+  async buildEnrollment(
+    email: string,
+    secret: string,
+  ): Promise<{ otpauthUrl: string; qrDataUrl: string }> {
+    const otpauthUrl = authenticator.keyuri(email, ISSUER, secret);
+    return { otpauthUrl, qrDataUrl: await toDataURL(otpauthUrl) };
+  }
+
+  verify(code: string, secret: string): boolean {
+    return authenticator.verify({ token: code, secret });
+  }
+}

--- a/src/modules/auth/temp-token.guard.ts
+++ b/src/modules/auth/temp-token.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+
+export type TempTokenPurpose = 'mfa' | 'mfa-setup';
+
+export interface TempTokenRequest extends Request {
+  userId: string;
+  tokenPurpose: TempTokenPurpose;
+}
+
+/**
+ * Guards the intermediate login steps: after password verification the client
+ * holds a short-lived token whose purpose is either completing MFA enrollment
+ * ('mfa-setup') or answering an MFA challenge ('mfa').
+ */
+@Injectable()
+export class TempTokenGuard implements CanActivate {
+  constructor(private readonly jwt: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<TempTokenRequest>();
+    const header = request.headers.authorization;
+    if (!header || !header.startsWith('Bearer ')) {
+      throw new UnauthorizedException();
+    }
+
+    try {
+      const payload = await this.jwt.verifyAsync<{ sub: string; type: string }>(
+        header.slice('Bearer '.length),
+      );
+      if (payload.type !== 'mfa' && payload.type !== 'mfa-setup') {
+        throw new UnauthorizedException();
+      }
+      request.userId = payload.sub;
+      request.tokenPurpose = payload.type;
+      return true;
+    } catch {
+      throw new UnauthorizedException();
+    }
+  }
+}

--- a/src/modules/auth/tokens.service.ts
+++ b/src/modules/auth/tokens.service.ts
@@ -1,0 +1,101 @@
+import { createHash, randomUUID } from 'crypto';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { eq } from 'drizzle-orm';
+import { Response } from 'express';
+import { durationToMs } from '../../common/duration';
+import { Database, DRIZZLE } from '../../db/db.module';
+import { sessions } from '../../db/schema';
+
+export const REFRESH_COOKIE = '_rt';
+const REFRESH_COOKIE_PATH = '/api/auth';
+
+export interface IssuedTokens {
+  accessToken: string;
+}
+
+@Injectable()
+export class TokensService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: Database,
+    private readonly jwt: JwtService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Issues a fresh access token and rotates the refresh token: the new jti hash
+   * overwrites the user's single session row, so any previously issued refresh
+   * token stops working immediately.
+   */
+  async issueTokens(userId: string, response: Response): Promise<IssuedTokens> {
+    const accessTtlMs = durationToMs(this.config.getOrThrow<string>('JWT_ACCESS_EXPIRES_IN'));
+    const accessToken = await this.jwt.signAsync(
+      { sub: userId, type: 'access' },
+      { expiresIn: accessTtlMs / 1000 },
+    );
+
+    const refreshTtlMs = durationToMs(this.config.getOrThrow<string>('JWT_REFRESH_EXPIRES_IN'));
+    const jti = randomUUID();
+    const refreshToken = await this.jwt.signAsync(
+      { sub: userId, type: 'refresh', jti },
+      { expiresIn: refreshTtlMs / 1000 },
+    );
+
+    const expiresAt = new Date(Date.now() + refreshTtlMs);
+    await this.db
+      .insert(sessions)
+      .values({ userId, refreshJtiHash: this.hash(jti), expiresAt })
+      .onConflictDoUpdate({
+        target: sessions.userId,
+        set: { refreshJtiHash: this.hash(jti), expiresAt, updatedAt: new Date() },
+      });
+
+    response.cookie(REFRESH_COOKIE, refreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      path: REFRESH_COOKIE_PATH,
+      maxAge: refreshTtlMs,
+    });
+
+    return { accessToken };
+  }
+
+  /**
+   * Validates a refresh token against the stored session. A structurally valid
+   * token whose jti does not match the current session is treated as replay of
+   * a rotated-out token — the whole session is revoked.
+   */
+  async verifyRefreshToken(token: string): Promise<string> {
+    let payload: { sub: string; type: string; jti: string };
+    try {
+      payload = await this.jwt.verifyAsync(token);
+    } catch {
+      throw new UnauthorizedException();
+    }
+    if (payload.type !== 'refresh') {
+      throw new UnauthorizedException();
+    }
+
+    const [session] = await this.db.select().from(sessions).where(eq(sessions.userId, payload.sub));
+    if (!session || session.expiresAt < new Date()) {
+      throw new UnauthorizedException();
+    }
+    if (session.refreshJtiHash !== this.hash(payload.jti)) {
+      await this.db.delete(sessions).where(eq(sessions.userId, payload.sub));
+      throw new UnauthorizedException();
+    }
+
+    return payload.sub;
+  }
+
+  async revokeSession(userId: string, response: Response): Promise<void> {
+    await this.db.delete(sessions).where(eq(sessions.userId, userId));
+    response.clearCookie(REFRESH_COOKIE, { path: REFRESH_COOKIE_PATH });
+  }
+
+  private hash(value: string): string {
+    return createHash('sha256').update(value).digest('hex');
+  }
+}

--- a/test/app.harness.ts
+++ b/test/app.harness.ts
@@ -1,0 +1,19 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { configureApp } from '../src/app.setup';
+import { Database, DRIZZLE } from '../src/db/db.module';
+
+export interface TestApp {
+  app: NestExpressApplication;
+  db: Database;
+}
+
+/** Boots the real AppModule with the exact production middleware/pipe setup. */
+export async function createTestApp(): Promise<TestApp> {
+  const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+  const app = moduleRef.createNestApplication<NestExpressApplication>();
+  configureApp(app);
+  await app.init();
+  return { app, db: app.get<Database>(DRIZZLE) };
+}

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,176 @@
+import { eq } from 'drizzle-orm';
+import { hashSync } from 'bcryptjs';
+import { authenticator } from 'otplib';
+import request from 'supertest';
+import { users } from '../src/db/schema';
+import { createTestApp, TestApp } from './app.harness';
+
+const EMAIL = 'e2e-auth@test.local';
+const PASSWORD = 'correct horse battery staple';
+const NEW_PASSWORD = 'an even longer battery staple';
+
+describe('Auth (e2e)', () => {
+  let ctx: TestApp;
+  let server: ReturnType<TestApp['app']['getHttpServer']>;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    server = ctx.app.getHttpServer();
+    await ctx.db.delete(users).where(eq(users.email, EMAIL));
+    await ctx.db.insert(users).values({ email: EMAIL, passwordHash: hashSync(PASSWORD, 10) });
+  });
+
+  afterAll(async () => {
+    await ctx.db.delete(users).where(eq(users.email, EMAIL));
+    await ctx.app.close();
+  });
+
+  let tempToken: string;
+  let totpSecret: string;
+  let accessToken: string;
+  let refreshCookie: string;
+
+  const extractRefreshCookie = (res: request.Response): string => {
+    const cookies = res.get('Set-Cookie');
+    if (!cookies) {
+      throw new Error('No Set-Cookie header in response');
+    }
+    const rt = cookies.find((c: string) => c.startsWith('_rt='));
+    if (!rt) {
+      throw new Error('No _rt cookie in response');
+    }
+    return rt;
+  };
+
+  it('rejects a wrong password', async () => {
+    await request(server)
+      .post('/api/auth/login')
+      .send({ email: EMAIL, password: 'wrong' })
+      .expect(401);
+  });
+
+  it('requires MFA enrollment on first login', async () => {
+    const res = await request(server)
+      .post('/api/auth/login')
+      .send({ email: EMAIL, password: PASSWORD })
+      .expect(200);
+    expect(res.body.mfaSetupRequired).toBe(true);
+    expect(res.body.tempToken).toBeDefined();
+    tempToken = res.body.tempToken;
+  });
+
+  it('serves an enrollment QR and otpauth URL', async () => {
+    const res = await request(server)
+      .get('/api/auth/mfa/setup')
+      .set('Authorization', `Bearer ${tempToken}`)
+      .expect(200);
+    expect(res.body.qrDataUrl).toMatch(/^data:image\/png;base64,/);
+    const url = new URL(res.body.otpauthUrl);
+    const secret = url.searchParams.get('secret');
+    if (!secret) {
+      throw new Error('otpauth URL has no secret');
+    }
+    totpSecret = secret;
+  });
+
+  it('rejects a wrong TOTP code on enable', async () => {
+    await request(server)
+      .post('/api/auth/mfa/enable')
+      .set('Authorization', `Bearer ${tempToken}`)
+      .send({ code: '000000' })
+      .expect(401);
+  });
+
+  it('enables MFA and issues tokens with hardened cookie flags', async () => {
+    const res = await request(server)
+      .post('/api/auth/mfa/enable')
+      .set('Authorization', `Bearer ${tempToken}`)
+      .send({ code: authenticator.generate(totpSecret) })
+      .expect(200);
+    expect(res.body.accessToken).toBeDefined();
+    accessToken = res.body.accessToken;
+
+    refreshCookie = extractRefreshCookie(res);
+    expect(refreshCookie).toContain('HttpOnly');
+    expect(refreshCookie).toContain('Secure');
+    expect(refreshCookie).toContain('SameSite=Strict');
+    expect(refreshCookie).toContain('Path=/api/auth');
+  });
+
+  it('guards admin routes against missing/temp tokens', async () => {
+    await request(server)
+      .put('/api/admin/password')
+      .send({ currentPassword: PASSWORD, newPassword: NEW_PASSWORD })
+      .expect(401);
+    await request(server)
+      .put('/api/admin/password')
+      .set('Authorization', `Bearer ${tempToken}`)
+      .send({ currentPassword: PASSWORD, newPassword: NEW_PASSWORD })
+      .expect(401);
+  });
+
+  it('changes the password with a valid access token', async () => {
+    await request(server)
+      .put('/api/admin/password')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ currentPassword: 'not the password', newPassword: NEW_PASSWORD })
+      .expect(401);
+    await request(server)
+      .put('/api/admin/password')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ currentPassword: PASSWORD, newPassword: NEW_PASSWORD })
+      .expect(204);
+  });
+
+  it('logs in with the new password and an MFA challenge', async () => {
+    const login = await request(server)
+      .post('/api/auth/login')
+      .send({ email: EMAIL, password: NEW_PASSWORD })
+      .expect(200);
+    expect(login.body.mfaRequired).toBe(true);
+
+    const verify = await request(server)
+      .post('/api/auth/mfa/verify')
+      .set('Authorization', `Bearer ${login.body.tempToken}`)
+      .send({ code: authenticator.generate(totpSecret) })
+      .expect(200);
+    accessToken = verify.body.accessToken;
+    refreshCookie = extractRefreshCookie(verify);
+  });
+
+  it('rotates refresh tokens and kills the session on replay', async () => {
+    const oldCookie = refreshCookie;
+
+    const first = await request(server)
+      .post('/api/auth/refresh')
+      .set('Cookie', oldCookie)
+      .expect(200);
+    expect(first.body.accessToken).toBeDefined();
+    const rotatedCookie = extractRefreshCookie(first);
+
+    // Replaying the rotated-out token must fail and revoke the whole session…
+    await request(server).post('/api/auth/refresh').set('Cookie', oldCookie).expect(401);
+    // …so even the newest token is now dead.
+    await request(server).post('/api/auth/refresh').set('Cookie', rotatedCookie).expect(401);
+  });
+
+  it('logout revokes the session', async () => {
+    const login = await request(server)
+      .post('/api/auth/login')
+      .send({ email: EMAIL, password: NEW_PASSWORD })
+      .expect(200);
+    const verify = await request(server)
+      .post('/api/auth/mfa/verify')
+      .set('Authorization', `Bearer ${login.body.tempToken}`)
+      .send({ code: authenticator.generate(totpSecret) })
+      .expect(200);
+    const cookie = extractRefreshCookie(verify);
+
+    await request(server)
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer ${verify.body.accessToken}`)
+      .expect(204);
+
+    await request(server).post('/api/auth/refresh').set('Cookie', cookie).expect(401);
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,0 +1,11 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testRegex": "test/.*\\.e2e-spec\\.ts$",
+  "transform": {
+    "^.+\\.ts$": ["ts-jest", { "tsconfig": "tsconfig.json" }]
+  },
+  "setupFiles": ["dotenv/config"],
+  "testTimeout": 30000
+}


### PR DESCRIPTION
Second milestone, stacked on #40 (merging that retargets this PR automatically).

## Flow
```
POST /api/auth/login {email, password}        -> {mfaSetupRequired|mfaRequired, tempToken (5m)}
GET  /api/auth/mfa/setup   (temp token)       -> {otpauthUrl, qrDataUrl}     # first login only
POST /api/auth/mfa/enable  {code}             -> {accessToken} + _rt cookie  # first login only
POST /api/auth/mfa/verify  {code}             -> {accessToken} + _rt cookie
POST /api/auth/refresh     (cookie)           -> {accessToken} + rotated cookie
POST /api/auth/logout      (Bearer)           -> 204, session revoked
PUT  /api/admin/password   (Bearer)           -> 204
```

## Hardening vs legacy
- `_rt` cookie now **HttpOnly + Secure + SameSite=Strict + Path=/api/auth** (legacy had none of the flags)
- Refresh **rotation with replay detection**: presenting a rotated-out (but signature-valid) refresh token revokes the entire session
- Auth endpoints throttled 5/min; access token moves to standard `Authorization: Bearer` (the legacy `X-Access-Token` + BasicAuth-in-bundle scheme is gone)
- TOTP via otplib with window 1 (same tolerance as the legacy speakeasy delta-0 setup)

## Verified
`npm run test:e2e`: **10/10 green** — wrong-password rejection, enrollment QR, wrong-code rejection, cookie flags, guard coverage (missing/temp tokens), password change, replay-kills-session, logout revocation. Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)