### PR TITLE
Rebuild A3: posts + full-text search + revalidation webhook

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,13 +5,19 @@ import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { DbModule } from './db/db.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { HealthModule } from './modules/health/health.module';
+import { PostsModule } from './modules/posts/posts.module';
+import { RevalidateModule } from './modules/revalidate/revalidate.module';
+import { SearchModule } from './modules/search/search.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 120 }]),
     DbModule,
+    RevalidateModule,
     AuthModule,
+    PostsModule,
+    SearchModule,
     HealthModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/src/modules/posts/dto/posts.dto.ts
+++ b/src/modules/posts/dto/posts.dto.ts
@@ -1,0 +1,111 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsUUID,
+  Matches,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+export const PER_PAGE_OPTIONS = [10, 25, 50] as const;
+
+export class ListPostsQueryDto {
+  @IsOptional()
+  @IsIn(['article', 'project'])
+  type?: 'article' | 'project';
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  featured?: boolean;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @Type(() => Number)
+  @IsIn(PER_PAGE_OPTIONS as unknown as number[])
+  per: number = 10;
+}
+
+export class AdminListPostsQueryDto {
+  @IsOptional()
+  @IsIn(['article', 'project'])
+  type?: 'article' | 'project';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  search?: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @Type(() => Number)
+  @IsIn(PER_PAGE_OPTIONS as unknown as number[])
+  per: number = 25;
+}
+
+export class CreatePostDto {
+  @IsIn(['article', 'project'])
+  type: 'article' | 'project';
+
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+    message: 'slug must be lowercase alphanumeric with single hyphens',
+  })
+  @MaxLength(120)
+  slug: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  title: string;
+
+  @IsString()
+  @MaxLength(500)
+  excerpt: string;
+
+  @IsString()
+  contentMd: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @MaxLength(40, { each: true })
+  tags: string[];
+
+  @IsBoolean()
+  featured: boolean;
+
+  @IsBoolean()
+  published: boolean;
+
+  @IsOptional()
+  @IsUrl()
+  repoUrl?: string;
+
+  @IsOptional()
+  @IsUUID()
+  heroAssetId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  seoTitle?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  seoDescription?: string;
+}
+
+export class UpdatePostDto extends CreatePostDto {}

--- a/src/modules/posts/posts-admin.controller.ts
+++ b/src/modules/posts/posts-admin.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AccessTokenGuard } from '../../common/guards/access-token.guard';
+import { AdminListPostsQueryDto, CreatePostDto, UpdatePostDto } from './dto/posts.dto';
+import { PostsService } from './posts.service';
+
+@Controller('admin/posts')
+@UseGuards(AccessTokenGuard)
+export class PostsAdminController {
+  constructor(private readonly posts: PostsService) {}
+
+  @Get()
+  list(@Query() query: AdminListPostsQueryDto) {
+    return this.posts.listAdmin(query);
+  }
+
+  @Get(':id')
+  byId(@Param('id', ParseUUIDPipe) id: string) {
+    return this.posts.getAdminById(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreatePostDto) {
+    return this.posts.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdatePostDto) {
+    return this.posts.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  async remove(@Param('id', ParseUUIDPipe) id: string) {
+    await this.posts.remove(id);
+  }
+}

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ListPostsQueryDto } from './dto/posts.dto';
+import { PostsService } from './posts.service';
+
+@Controller('posts')
+export class PostsController {
+  constructor(private readonly posts: PostsService) {}
+
+  @Get()
+  list(@Query() query: ListPostsQueryDto) {
+    return this.posts.listPublic(query);
+  }
+
+  @Get('slugs')
+  slugs() {
+    return this.posts.listPublishedSlugs();
+  }
+
+  @Get(':slug')
+  bySlug(@Param('slug') slug: string) {
+    return this.posts.getPublicBySlug(slug);
+  }
+}

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PostsAdminController } from './posts-admin.controller';
+import { PostsController } from './posts.controller';
+import { PostsService } from './posts.service';
+
+@Module({
+  controllers: [PostsController, PostsAdminController],
+  providers: [PostsService],
+})
+export class PostsModule {}

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -1,0 +1,215 @@
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { and, desc, eq, ilike, sql, SQL } from 'drizzle-orm';
+import { markdownToPlainText, readingTimeMin } from '../../common/content';
+import { Database, DRIZZLE } from '../../db/db.module';
+import { assets, posts } from '../../db/schema';
+import { RevalidateService } from '../revalidate/revalidate.service';
+import {
+  AdminListPostsQueryDto,
+  CreatePostDto,
+  ListPostsQueryDto,
+  UpdatePostDto,
+} from './dto/posts.dto';
+
+@Injectable()
+export class PostsService {
+  private readonly s3PublicUrl: string;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: Database,
+    private readonly revalidate: RevalidateService,
+    config: ConfigService,
+  ) {
+    this.s3PublicUrl = config.getOrThrow<string>('S3_PUBLIC_URL');
+  }
+
+  private heroUrl(s3Key: string | null): string | null {
+    return s3Key ? `${this.s3PublicUrl}/${s3Key}` : null;
+  }
+
+  async listPublic(query: ListPostsQueryDto) {
+    const conditions: SQL[] = [eq(posts.published, true)];
+    if (query.type) {
+      conditions.push(eq(posts.type, query.type));
+    }
+    if (query.featured !== undefined) {
+      conditions.push(eq(posts.featured, query.featured));
+    }
+    const where = and(...conditions);
+
+    const [{ total }] = await this.db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(posts)
+      .where(where);
+
+    const items = await this.db
+      .select({
+        slug: posts.slug,
+        type: posts.type,
+        title: posts.title,
+        excerpt: posts.excerpt,
+        tags: posts.tags,
+        publishedAt: posts.publishedAt,
+        readingTimeMin: posts.readingTimeMin,
+        repoUrl: posts.repoUrl,
+        heroKey: assets.s3Key,
+      })
+      .from(posts)
+      .leftJoin(assets, eq(posts.heroAssetId, assets.id))
+      .where(where)
+      .orderBy(desc(posts.publishedAt))
+      .limit(query.per)
+      .offset((query.page - 1) * query.per);
+
+    return {
+      items: items.map(({ heroKey, ...item }) => ({ ...item, heroUrl: this.heroUrl(heroKey) })),
+      total,
+      page: query.page,
+      per: query.per,
+    };
+  }
+
+  async getPublicBySlug(slug: string) {
+    const [row] = await this.db
+      .select({
+        slug: posts.slug,
+        type: posts.type,
+        title: posts.title,
+        excerpt: posts.excerpt,
+        contentMd: posts.contentMd,
+        tags: posts.tags,
+        publishedAt: posts.publishedAt,
+        updatedAt: posts.updatedAt,
+        readingTimeMin: posts.readingTimeMin,
+        repoUrl: posts.repoUrl,
+        seoTitle: posts.seoTitle,
+        seoDescription: posts.seoDescription,
+        heroKey: assets.s3Key,
+      })
+      .from(posts)
+      .leftJoin(assets, eq(posts.heroAssetId, assets.id))
+      .where(and(eq(posts.slug, slug), eq(posts.published, true)));
+
+    if (!row) {
+      throw new NotFoundException();
+    }
+    const { heroKey, ...post } = row;
+    return { ...post, heroUrl: this.heroUrl(heroKey) };
+  }
+
+  async listPublishedSlugs() {
+    return this.db
+      .select({ slug: posts.slug, type: posts.type, updatedAt: posts.updatedAt })
+      .from(posts)
+      .where(eq(posts.published, true))
+      .orderBy(desc(posts.publishedAt));
+  }
+
+  // --- admin ----------------------------------------------------------------
+
+  async listAdmin(query: AdminListPostsQueryDto) {
+    const conditions: SQL[] = [];
+    if (query.type) {
+      conditions.push(eq(posts.type, query.type));
+    }
+    if (query.search) {
+      conditions.push(ilike(posts.title, `%${query.search}%`));
+    }
+    const where = conditions.length ? and(...conditions) : undefined;
+
+    const [{ total }] = await this.db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(posts)
+      .where(where);
+
+    const items = await this.db
+      .select({
+        id: posts.id,
+        slug: posts.slug,
+        type: posts.type,
+        title: posts.title,
+        featured: posts.featured,
+        published: posts.published,
+        publishedAt: posts.publishedAt,
+        updatedAt: posts.updatedAt,
+      })
+      .from(posts)
+      .where(where)
+      .orderBy(desc(posts.updatedAt))
+      .limit(query.per)
+      .offset((query.page - 1) * query.per);
+
+    return { items, total, page: query.page, per: query.per };
+  }
+
+  async getAdminById(id: string) {
+    const [post] = await this.db.select().from(posts).where(eq(posts.id, id));
+    if (!post) {
+      throw new NotFoundException();
+    }
+    return post;
+  }
+
+  async create(dto: CreatePostDto) {
+    await this.assertSlugFree(dto.slug);
+
+    const [created] = await this.db
+      .insert(posts)
+      .values({
+        ...dto,
+        plainText: markdownToPlainText(dto.contentMd, dto.tags),
+        readingTimeMin: readingTimeMin(dto.contentMd),
+        publishedAt: dto.published ? new Date() : null,
+      })
+      .returning();
+
+    this.revalidate.notify(['posts', `post:${created.slug}`]);
+    return created;
+  }
+
+  async update(id: string, dto: UpdatePostDto) {
+    const existing = await this.getAdminById(id);
+    if (dto.slug !== existing.slug) {
+      await this.assertSlugFree(dto.slug);
+    }
+
+    const [updated] = await this.db
+      .update(posts)
+      .set({
+        ...dto,
+        // repoUrl/heroAssetId/seo fields absent in the payload mean "cleared"
+        repoUrl: dto.repoUrl ?? null,
+        heroAssetId: dto.heroAssetId ?? null,
+        seoTitle: dto.seoTitle ?? null,
+        seoDescription: dto.seoDescription ?? null,
+        plainText: markdownToPlainText(dto.contentMd, dto.tags),
+        readingTimeMin: readingTimeMin(dto.contentMd),
+        // published_at is stamped exactly once, on the first transition to published
+        publishedAt: dto.published && !existing.publishedAt ? new Date() : existing.publishedAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(posts.id, id))
+      .returning();
+
+    const tags = ['posts', `post:${updated.slug}`];
+    if (existing.slug !== updated.slug) {
+      tags.push(`post:${existing.slug}`);
+    }
+    this.revalidate.notify(tags);
+    return updated;
+  }
+
+  async remove(id: string) {
+    const existing = await this.getAdminById(id);
+    await this.db.delete(posts).where(eq(posts.id, id));
+    this.revalidate.notify(['posts', `post:${existing.slug}`]);
+  }
+
+  private async assertSlugFree(slug: string) {
+    const [clash] = await this.db.select({ id: posts.id }).from(posts).where(eq(posts.slug, slug));
+    if (clash) {
+      throw new ConflictException(`Slug '${slug}' is already in use`);
+    }
+  }
+}

--- a/src/modules/revalidate/revalidate.module.ts
+++ b/src/modules/revalidate/revalidate.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { RevalidateService } from './revalidate.service';
+
+@Global()
+@Module({
+  providers: [RevalidateService],
+  exports: [RevalidateService],
+})
+export class RevalidateModule {}

--- a/src/modules/revalidate/revalidate.service.ts
+++ b/src/modules/revalidate/revalidate.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Notifies the Next.js frontend that cached content changed. Fire-and-forget:
+ * content mutations must not fail because the frontend is unreachable — the
+ * front's time-based revalidation fallback will catch up.
+ */
+@Injectable()
+export class RevalidateService {
+  private readonly logger = new Logger(RevalidateService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  notify(tags: string[]): void {
+    const frontUrl = this.config.getOrThrow<string>('FRONT_INTERNAL_URL');
+    const secret = this.config.getOrThrow<string>('REVALIDATE_SECRET');
+
+    fetch(`${frontUrl}/api/revalidate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ secret, tags }),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          this.logger.warn(`Revalidation for [${tags.join(', ')}] returned ${res.status}`);
+        }
+      })
+      .catch((err: Error) => {
+        this.logger.warn(`Revalidation for [${tags.join(', ')}] failed: ${err.message}`);
+      });
+  }
+}

--- a/src/modules/search/search.controller.ts
+++ b/src/modules/search/search.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { Type } from 'class-transformer';
+import { IsInt, IsString, Max, MaxLength, Min } from 'class-validator';
+import { SearchService } from './search.service';
+
+class SearchQueryDto {
+  @IsString()
+  @MaxLength(100)
+  q: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  per: number = 20;
+}
+
+@Controller('search')
+export class SearchController {
+  constructor(private readonly search: SearchService) {}
+
+  @Get()
+  run(@Query() query: SearchQueryDto) {
+    return this.search.search(query.q, query.page, query.per);
+  }
+}

--- a/src/modules/search/search.module.ts
+++ b/src/modules/search/search.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+
+@Module({
+  controllers: [SearchController],
+  providers: [SearchService],
+})
+export class SearchModule {}

--- a/src/modules/search/search.service.ts
+++ b/src/modules/search/search.service.ts
@@ -1,0 +1,86 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { sql, SQL } from 'drizzle-orm';
+import { Database, DRIZZLE } from '../../db/db.module';
+
+export interface SearchResultItem {
+  slug: string;
+  type: 'article' | 'project';
+  tags: string[];
+  publishedAt: string;
+  /** Title with matches wrapped in <mark> — only that tag, produced by ts_headline. */
+  titleHtml: string;
+  snippetHtml: string;
+}
+
+type SearchRow = {
+  slug: string;
+  type: 'article' | 'project';
+  tags: string[];
+  published_at: string;
+  title_html: string;
+  snippet_html: string;
+};
+
+const HEADLINE_TITLE = 'StartSel=<mark>,StopSel=</mark>,HighlightAll=true';
+const HEADLINE_SNIPPET = 'StartSel=<mark>,StopSel=</mark>,MaxWords=22,MinWords=10,MaxFragments=1';
+
+@Injectable()
+export class SearchService {
+  constructor(@Inject(DRIZZLE) private readonly db: Database) {}
+
+  async search(rawQuery: string, page: number, per: number) {
+    const empty = { items: [] as SearchResultItem[], total: 0, page, per };
+    const query = rawQuery.trim();
+    if (query.length < 2) {
+      return empty;
+    }
+
+    // Single tokens get prefix matching so the popup finds half-typed words;
+    // multi-word queries go through websearch syntax (quotes, or, -).
+    let tsquery: SQL;
+    if (/\s/.test(query)) {
+      tsquery = sql`websearch_to_tsquery('english', ${query})`;
+    } else {
+      const token = query.replace(/[^\p{L}\p{N}]/gu, '');
+      if (token.length < 2) {
+        return empty;
+      }
+      tsquery = sql`to_tsquery('english', ${token + ':*'})`;
+    }
+
+    const countResult = await this.db.execute<{ total: number }>(sql`
+      SELECT count(*)::int AS total
+      FROM posts, (SELECT ${tsquery} AS tsq) q
+      WHERE published AND search @@ q.tsq
+    `);
+    const total = countResult.rows[0].total;
+    if (total === 0) {
+      return empty;
+    }
+
+    const result = await this.db.execute<SearchRow>(sql`
+      SELECT
+        slug,
+        type,
+        tags,
+        published_at,
+        ts_headline('english', title, q.tsq, ${HEADLINE_TITLE}) AS title_html,
+        ts_headline('english', plain_text, q.tsq, ${HEADLINE_SNIPPET}) AS snippet_html
+      FROM posts, (SELECT ${tsquery} AS tsq) q
+      WHERE published AND search @@ q.tsq
+      ORDER BY ts_rank_cd(search, q.tsq) DESC, published_at DESC
+      LIMIT ${per} OFFSET ${(page - 1) * per}
+    `);
+
+    const items: SearchResultItem[] = result.rows.map((row) => ({
+      slug: row.slug,
+      type: row.type,
+      tags: row.tags,
+      publishedAt: row.published_at,
+      titleHtml: row.title_html,
+      snippetHtml: row.snippet_html,
+    }));
+
+    return { items, total, page, per };
+  }
+}

--- a/test/auth-helper.ts
+++ b/test/auth-helper.ts
@@ -1,0 +1,21 @@
+import { JwtService } from '@nestjs/jwt';
+import { hashSync } from 'bcryptjs';
+import { eq } from 'drizzle-orm';
+import { users } from '../src/db/schema';
+import { TestApp } from './app.harness';
+
+/** Creates (or resets) a dedicated test user and mints a real access token for it. */
+export async function createAuthedUser(ctx: TestApp, email: string): Promise<string> {
+  await ctx.db.delete(users).where(eq(users.email, email));
+  const [user] = await ctx.db
+    .insert(users)
+    .values({ email, passwordHash: hashSync('irrelevant-for-these-tests', 10), mfaEnabled: true })
+    .returning();
+
+  const jwt = ctx.app.get(JwtService);
+  return jwt.signAsync({ sub: user.id, type: 'access' }, { expiresIn: 600 });
+}
+
+export async function deleteUser(ctx: TestApp, email: string): Promise<void> {
+  await ctx.db.delete(users).where(eq(users.email, email));
+}

--- a/test/posts.e2e-spec.ts
+++ b/test/posts.e2e-spec.ts
@@ -1,0 +1,142 @@
+import { inArray } from 'drizzle-orm';
+import request from 'supertest';
+import { posts } from '../src/db/schema';
+import { createTestApp, TestApp } from './app.harness';
+import { createAuthedUser, deleteUser } from './auth-helper';
+
+const USER_EMAIL = 'e2e-posts@test.local';
+const SLUGS = ['e2e-first-post', 'e2e-renamed-post', 'e2e-second-post'];
+
+const basePost = {
+  type: 'article' as const,
+  title: 'E2E first post',
+  excerpt: 'An excerpt for the first post.',
+  contentMd: '## Heading\n\nSome **markdown** content with `code` and enough words to count.',
+  tags: ['e2e', 'testing'],
+  featured: false,
+  published: false,
+};
+
+describe('Posts (e2e)', () => {
+  let ctx: TestApp;
+  let server: ReturnType<TestApp['app']['getHttpServer']>;
+  let token: string;
+  let postId: string;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    server = ctx.app.getHttpServer();
+    token = await createAuthedUser(ctx, USER_EMAIL);
+    await ctx.db.delete(posts).where(inArray(posts.slug, SLUGS));
+  });
+
+  afterAll(async () => {
+    await ctx.db.delete(posts).where(inArray(posts.slug, SLUGS));
+    await deleteUser(ctx, USER_EMAIL);
+    await ctx.app.close();
+  });
+
+  it('rejects unauthenticated admin access', async () => {
+    await request(server).post('/api/admin/posts').send(basePost).expect(401);
+  });
+
+  it('creates a draft with computed reading time and plain text', async () => {
+    const res = await request(server)
+      .post('/api/admin/posts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...basePost, slug: SLUGS[0] })
+      .expect(201);
+    postId = res.body.id;
+    expect(res.body.publishedAt).toBeNull();
+    expect(res.body.readingTimeMin).toBe(1);
+    expect(res.body.plainText).toContain('markdown content');
+    expect(res.body.plainText).not.toContain('**');
+    expect(res.body.plainText).toContain('e2e testing');
+  });
+
+  it('rejects a duplicate slug with 409', async () => {
+    await request(server)
+      .post('/api/admin/posts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...basePost, slug: SLUGS[0] })
+      .expect(409);
+  });
+
+  it('hides drafts from the public endpoints', async () => {
+    const list = await request(server).get('/api/posts?type=article').expect(200);
+    const slugs = list.body.items.map((i: { slug: string }) => i.slug);
+    expect(slugs).not.toContain(SLUGS[0]);
+
+    await request(server).get(`/api/posts/${SLUGS[0]}`).expect(404);
+
+    const slugList = await request(server).get('/api/posts/slugs').expect(200);
+    expect(slugList.body.map((s: { slug: string }) => s.slug)).not.toContain(SLUGS[0]);
+  });
+
+  it('publishes a draft and stamps published_at exactly once', async () => {
+    const published = await request(server)
+      .put(`/api/admin/posts/${postId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...basePost, slug: SLUGS[0], published: true })
+      .expect(200);
+    const firstPublishedAt = published.body.publishedAt;
+    expect(firstPublishedAt).not.toBeNull();
+
+    const republished = await request(server)
+      .put(`/api/admin/posts/${postId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...basePost, slug: SLUGS[0], published: true, title: 'E2E first post (edited)' })
+      .expect(200);
+    expect(republished.body.publishedAt).toBe(firstPublishedAt);
+  });
+
+  it('serves the published post publicly', async () => {
+    const res = await request(server).get(`/api/posts/${SLUGS[0]}`).expect(200);
+    expect(res.body.title).toBe('E2E first post (edited)');
+    expect(res.body.contentMd).toContain('## Heading');
+    // The search projection stays internal
+    expect(res.body.plainText).toBeUndefined();
+  });
+
+  it('renames a slug without losing the post', async () => {
+    await request(server)
+      .put(`/api/admin/posts/${postId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ ...basePost, slug: SLUGS[1], published: true })
+      .expect(200);
+    await request(server).get(`/api/posts/${SLUGS[1]}`).expect(200);
+    await request(server).get(`/api/posts/${SLUGS[0]}`).expect(404);
+  });
+
+  it('filters featured posts', async () => {
+    await request(server)
+      .post('/api/admin/posts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        ...basePost,
+        slug: SLUGS[2],
+        title: 'E2E second post',
+        featured: true,
+        published: true,
+      })
+      .expect(201);
+
+    const res = await request(server).get('/api/posts?type=article&featured=true').expect(200);
+    const slugs = res.body.items.map((i: { slug: string }) => i.slug);
+    expect(slugs).toContain(SLUGS[2]);
+    expect(slugs).not.toContain(SLUGS[1]);
+  });
+
+  it('validates pagination parameters', async () => {
+    await request(server).get('/api/posts?per=15').expect(400);
+    await request(server).get('/api/posts?page=0').expect(400);
+  });
+
+  it('deletes a post', async () => {
+    await request(server)
+      .delete(`/api/admin/posts/${postId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(204);
+    await request(server).get(`/api/posts/${SLUGS[1]}`).expect(404);
+  });
+});

--- a/test/search.e2e-spec.ts
+++ b/test/search.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { inArray } from 'drizzle-orm';
+import request from 'supertest';
+import { markdownToPlainText } from '../src/common/content';
+import { posts } from '../src/db/schema';
+import { createTestApp, TestApp } from './app.harness';
+
+const SLUGS = ['e2e-search-quokka', 'e2e-search-wombat', 'e2e-search-draft'];
+
+describe('Search (e2e)', () => {
+  let ctx: TestApp;
+  let server: ReturnType<TestApp['app']['getHttpServer']>;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    server = ctx.app.getHttpServer();
+    await ctx.db.delete(posts).where(inArray(posts.slug, SLUGS));
+
+    const mk = (slug: string, title: string, content: string, published: boolean) => ({
+      type: 'article' as const,
+      slug,
+      title,
+      excerpt: `${title} excerpt`,
+      contentMd: content,
+      plainText: markdownToPlainText(content, ['e2e-search']),
+      tags: ['e2e-search'],
+      featured: false,
+      published,
+      publishedAt: published ? new Date('2026-01-15T00:00:00Z') : null,
+    });
+
+    await ctx.db
+      .insert(posts)
+      .values([
+        mk(
+          SLUGS[0],
+          'Tracking quokka movements with telemetry',
+          'Long-term quokka telemetry reveals movement baselining opportunities for marsupial detection.',
+          true,
+        ),
+        mk(
+          SLUGS[1],
+          'Wombat burrow architecture',
+          'Wombats dig structured burrows. Nothing about the other marsupial here.',
+          true,
+        ),
+        mk(
+          SLUGS[2],
+          'Secret quokka draft',
+          'Unpublished quokka research that must not leak through search.',
+          false,
+        ),
+      ]);
+  });
+
+  afterAll(async () => {
+    await ctx.db.delete(posts).where(inArray(posts.slug, SLUGS));
+    await ctx.app.close();
+  });
+
+  it('finds full-word matches and wraps them in <mark>', async () => {
+    const res = await request(server).get('/api/search?q=quokka telemetry').expect(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.items[0].slug).toBe(SLUGS[0]);
+    expect(res.body.items[0].titleHtml).toContain('<mark>');
+    expect(res.body.items[0].snippetHtml).toContain('<mark>');
+  });
+
+  it('prefix-matches single tokens for typeahead', async () => {
+    const res = await request(server).get('/api/search?q=quok').expect(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.items[0].slug).toBe(SLUGS[0]);
+  });
+
+  it('matches across title and body with ranking', async () => {
+    const res = await request(server).get('/api/search?q=marsupial').expect(200);
+    expect(res.body.total).toBe(2);
+    const slugs = res.body.items.map((i: { slug: string }) => i.slug);
+    expect(slugs).toEqual(expect.arrayContaining([SLUGS[0], SLUGS[1]]));
+  });
+
+  it('never returns drafts', async () => {
+    const res = await request(server).get('/api/search?q=quokka').expect(200);
+    const slugs = res.body.items.map((i: { slug: string }) => i.slug);
+    expect(slugs).not.toContain(SLUGS[2]);
+  });
+
+  it('returns empty results for too-short or operator-only queries', async () => {
+    const short = await request(server).get('/api/search?q=a').expect(200);
+    expect(short.body.total).toBe(0);
+    const ops = await request(server).get('/api/search?q=!!').expect(200);
+    expect(ops.body.total).toBe(0);
+  });
+
+  it('returns an empty set for no matches', async () => {
+    const res = await request(server).get('/api/search?q=xyzzynomatch').expect(200);
+    expect(res.body).toEqual({ items: [], total: 0, page: 1, per: 20 });
+  });
+});


### PR DESCRIPTION
Third milestone, stacked on #41.

## Public API
| Endpoint | Behavior |
| --- | --- |
| `GET /api/posts?type=&featured=&page=&per=` | published only, `per` ∈ {10,25,50}, newest first, hero asset resolved to a public URL |
| `GET /api/posts/:slug` | full post incl. markdown; 404 for drafts/unknown |
| `GET /api/posts/slugs` | slug+type+updatedAt for sitemap/RSS |
| `GET /api/search?q=&page=&per=` | FTS with `<mark>`-highlighted titles + snippets |

## Search design
- Stored generated `tsvector` (title ^A, excerpt ^B, plain_text ^C) + GIN — set up in A1
- Multi-word queries → `websearch_to_tsquery` (supports quotes/or/minus); single tokens → sanitized prefix `to_tsquery('tok:*')` so the popup matches half-typed words
- `ts_headline` emits only `<mark>` tags; `plain_text` is markdown-stripped at save so snippets never leak markdown syntax

## Admin
CRUD under `/api/admin/posts` (Bearer): saves recompute `plain_text` + reading time, `published_at` stamps exactly once on first publish, slug conflicts 409, renames revalidate both old and new slug. Every mutation fires a fire-and-forget revalidation webhook to the front (`{secret, tags[]}`) — front lands in F5.

## Verified
`npm run test:e2e`: **26/26 green** (10 auth + 10 posts + 6 search). Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)