### PR TITLE
Rebuild A4: S3 assets + about/CV + site config

### DIFF
--- a/drizzle/0001_seed_singletons.sql
+++ b/drizzle/0001_seed_singletons.sql
@@ -1,0 +1,4 @@
+-- The site_config and about tables are singletons (CHECK id = 1). Creating the
+-- rows here guarantees every environment has them without depending on seeds.
+INSERT INTO "site_config" ("id") VALUES (1) ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO "about" ("id") VALUES (1) ON CONFLICT DO NOTHING;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,882 @@
+{
+  "id": "baa7a98c-c839-4591-938a-0f3a3c74e20a",
+  "prevId": "2ceb39e9-039c-4d13-9ee8-a0a09b85aa4b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.about": {
+      "name": "about",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar_asset_id": {
+          "name": "avatar_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_md": {
+          "name": "profile_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "about_avatar_asset_id_assets_id_fk": {
+          "name": "about_avatar_asset_id_assets_id_fk",
+          "tableFrom": "about",
+          "columnsFrom": [
+            "avatar_asset_id"
+          ],
+          "tableTo": "assets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "about_singleton": {
+          "name": "about_singleton",
+          "value": "\"about\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_s3_key_unique": {
+          "name": "assets_s3_key_unique",
+          "columns": [
+            "s3_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certifications": {
+      "name": "certifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_date": {
+          "name": "issued_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_date": {
+          "name": "expires_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_url": {
+          "name": "credential_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certifications_logo_asset_id_assets_id_fk": {
+          "name": "certifications_logo_asset_id_assets_id_fk",
+          "tableFrom": "certifications",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "tableTo": "assets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education": {
+      "name": "education",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "education_logo_asset_id_assets_id_fk": {
+          "name": "education_logo_asset_id_assets_id_fk",
+          "tableFrom": "education",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "tableTo": "assets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_url": {
+          "name": "company_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bullets": {
+          "name": "bullets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "positions_logo_asset_id_assets_id_fk": {
+          "name": "positions_logo_asset_id_assets_id_fk",
+          "tableFrom": "positions",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "tableTo": "assets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "plain_text": {
+          "name": "plain_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_time_min": {
+          "name": "reading_time_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "hero_asset_id": {
+          "name": "hero_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search": {
+          "name": "search",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('english', \"posts\".\"title\"), 'A') || setweight(to_tsvector('english', \"posts\".\"excerpt\"), 'B') || setweight(to_tsvector('english', \"posts\".\"plain_text\"), 'C')"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_search_idx": {
+          "name": "posts_search_idx",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "posts_listing_idx": {
+          "name": "posts_listing_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "posts_hero_asset_id_assets_id_fk": {
+          "name": "posts_hero_asset_id_assets_id_fk",
+          "tableFrom": "posts",
+          "columnsFrom": [
+            "hero_asset_id"
+          ],
+          "tableTo": "assets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_jti_hash": {
+          "name": "refresh_jti_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_user_id_unique": {
+          "name": "sessions_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_config": {
+      "name": "site_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "hero_title": {
+          "name": "hero_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hero_intro_md": {
+          "name": "hero_intro_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "seo_default_title": {
+          "name": "seo_default_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seo_default_description": {
+          "name": "seo_default_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_text": {
+          "name": "footer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "site_config_singleton": {
+          "name": "site_config_singleton",
+          "value": "\"site_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "article",
+        "project"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1786200986313,
       "tag": "0000_legal_vulcan",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1786201764266,
+      "tag": "0001_seed_singletons",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,10 @@ import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { DbModule } from './db/db.module';
+import { AboutModule } from './modules/about/about.module';
+import { AssetsModule } from './modules/assets/assets.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { SiteConfigModule } from './modules/config/config.module';
 import { HealthModule } from './modules/health/health.module';
 import { PostsModule } from './modules/posts/posts.module';
 import { RevalidateModule } from './modules/revalidate/revalidate.module';
@@ -18,6 +21,9 @@ import { SearchModule } from './modules/search/search.module';
     AuthModule,
     PostsModule,
     SearchModule,
+    AssetsModule,
+    AboutModule,
+    SiteConfigModule,
     HealthModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/src/modules/about/about-admin.controller.ts
+++ b/src/modules/about/about-admin.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { AccessTokenGuard } from '../../common/guards/access-token.guard';
+import { certifications, education, positions } from '../../db/schema';
+import { AboutService } from './about.service';
+import { CertificationDto, EducationDto, PositionDto, UpdateAboutDto } from './dto/about.dto';
+
+@Controller('admin')
+@UseGuards(AccessTokenGuard)
+export class AboutAdminController {
+  constructor(private readonly about: AboutService) {}
+
+  @Get('about')
+  get() {
+    return this.about.getAdmin();
+  }
+
+  @Put('about')
+  update(@Body() dto: UpdateAboutDto) {
+    return this.about.updateAbout(dto);
+  }
+
+  // --- positions ------------------------------------------------------------
+
+  @Post('positions')
+  createPosition(@Body() dto: PositionDto) {
+    return this.about.createEntry(positions, dto);
+  }
+
+  @Put('positions/:id')
+  updatePosition(@Param('id', ParseUUIDPipe) id: string, @Body() dto: PositionDto) {
+    return this.about.updateEntry(positions, id, dto);
+  }
+
+  @Delete('positions/:id')
+  @HttpCode(204)
+  async removePosition(@Param('id', ParseUUIDPipe) id: string) {
+    await this.about.removeEntry(positions, id);
+  }
+
+  // --- education ------------------------------------------------------------
+
+  @Post('education')
+  createEducation(@Body() dto: EducationDto) {
+    return this.about.createEntry(education, dto);
+  }
+
+  @Put('education/:id')
+  updateEducation(@Param('id', ParseUUIDPipe) id: string, @Body() dto: EducationDto) {
+    return this.about.updateEntry(education, id, dto);
+  }
+
+  @Delete('education/:id')
+  @HttpCode(204)
+  async removeEducation(@Param('id', ParseUUIDPipe) id: string) {
+    await this.about.removeEntry(education, id);
+  }
+
+  // --- certifications -------------------------------------------------------
+
+  @Post('certifications')
+  createCertification(@Body() dto: CertificationDto) {
+    return this.about.createEntry(certifications, dto);
+  }
+
+  @Put('certifications/:id')
+  updateCertification(@Param('id', ParseUUIDPipe) id: string, @Body() dto: CertificationDto) {
+    return this.about.updateEntry(certifications, id, dto);
+  }
+
+  @Delete('certifications/:id')
+  @HttpCode(204)
+  async removeCertification(@Param('id', ParseUUIDPipe) id: string) {
+    await this.about.removeEntry(certifications, id);
+  }
+}

--- a/src/modules/about/about.controller.ts
+++ b/src/modules/about/about.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AboutService } from './about.service';
+
+@Controller('about')
+export class AboutController {
+  constructor(private readonly about: AboutService) {}
+
+  @Get()
+  get() {
+    return this.about.getPublic();
+  }
+}

--- a/src/modules/about/about.module.ts
+++ b/src/modules/about/about.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AboutAdminController } from './about-admin.controller';
+import { AboutController } from './about.controller';
+import { AboutService } from './about.service';
+
+@Module({
+  controllers: [AboutController, AboutAdminController],
+  providers: [AboutService],
+})
+export class AboutModule {}

--- a/src/modules/about/about.service.ts
+++ b/src/modules/about/about.service.ts
@@ -1,0 +1,170 @@
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { asc, desc, eq } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { Database, DRIZZLE } from '../../db/db.module';
+import { about, assets, certifications, education, positions } from '../../db/schema';
+import { RevalidateService } from '../revalidate/revalidate.service';
+import { CertificationDto, EducationDto, PositionDto, UpdateAboutDto } from './dto/about.dto';
+
+type CvTable = typeof positions | typeof education | typeof certifications;
+
+@Injectable()
+export class AboutService {
+  private readonly publicUrl: string;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: Database,
+    private readonly revalidate: RevalidateService,
+    config: ConfigService,
+  ) {
+    this.publicUrl = config.getOrThrow<string>('S3_PUBLIC_URL');
+  }
+
+  private url(s3Key: string | null): string | null {
+    return s3Key ? `${this.publicUrl}/${s3Key}` : null;
+  }
+
+  async getPublic() {
+    const avatarAssets = alias(assets, 'avatar_assets');
+    const [aboutRow] = await this.db
+      .select({
+        fullName: about.fullName,
+        profileMd: about.profileMd,
+        location: about.location,
+        contactEmail: about.contactEmail,
+        seoTitle: about.seoTitle,
+        seoDescription: about.seoDescription,
+        avatarKey: avatarAssets.s3Key,
+      })
+      .from(about)
+      .leftJoin(avatarAssets, eq(about.avatarAssetId, avatarAssets.id))
+      .where(eq(about.id, 1));
+    if (!aboutRow) {
+      throw new InternalServerErrorException('about singleton row is missing');
+    }
+
+    const positionRows = await this.db
+      .select({ row: positions, logoKey: assets.s3Key })
+      .from(positions)
+      .leftJoin(assets, eq(positions.logoAssetId, assets.id))
+      .orderBy(asc(positions.sortOrder), desc(positions.startDate));
+
+    const educationRows = await this.db
+      .select({ row: education, logoKey: assets.s3Key })
+      .from(education)
+      .leftJoin(assets, eq(education.logoAssetId, assets.id))
+      .orderBy(asc(education.sortOrder), desc(education.startDate));
+
+    const certificationRows = await this.db
+      .select({ row: certifications, logoKey: assets.s3Key })
+      .from(certifications)
+      .leftJoin(assets, eq(certifications.logoAssetId, assets.id))
+      .orderBy(asc(certifications.sortOrder), desc(certifications.issuedDate));
+
+    const { avatarKey, ...aboutData } = aboutRow;
+    const strip = <T extends { row: Record<string, unknown>; logoKey: string | null }>(
+      items: T[],
+    ) =>
+      items.map(({ row, logoKey }) => {
+        const { logoAssetId: _logoAssetId, ...rest } = row;
+        return { ...rest, logoUrl: this.url(logoKey) };
+      });
+
+    return {
+      ...aboutData,
+      avatarUrl: this.url(avatarKey),
+      positions: strip(positionRows),
+      education: strip(educationRows),
+      certifications: strip(certificationRows),
+    };
+  }
+
+  // --- admin ----------------------------------------------------------------
+
+  async getAdmin() {
+    const [aboutRow] = await this.db.select().from(about).where(eq(about.id, 1));
+    if (!aboutRow) {
+      throw new InternalServerErrorException('about singleton row is missing');
+    }
+    return {
+      about: aboutRow,
+      positions: await this.db
+        .select()
+        .from(positions)
+        .orderBy(asc(positions.sortOrder), desc(positions.startDate)),
+      education: await this.db
+        .select()
+        .from(education)
+        .orderBy(asc(education.sortOrder), desc(education.startDate)),
+      certifications: await this.db
+        .select()
+        .from(certifications)
+        .orderBy(asc(certifications.sortOrder), desc(certifications.issuedDate)),
+    };
+  }
+
+  async updateAbout(dto: UpdateAboutDto) {
+    const [updated] = await this.db
+      .update(about)
+      .set({
+        ...dto,
+        avatarAssetId: dto.avatarAssetId ?? null,
+        seoTitle: dto.seoTitle ?? null,
+        seoDescription: dto.seoDescription ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(about.id, 1))
+      .returning();
+    this.revalidate.notify(['about']);
+    return updated;
+  }
+
+  async createEntry(table: CvTable, dto: PositionDto | EducationDto | CertificationDto) {
+    const [created] = await this.db.insert(table).values(this.normalize(dto)).returning();
+    this.revalidate.notify(['about']);
+    return created;
+  }
+
+  async updateEntry(
+    table: CvTable,
+    id: string,
+    dto: PositionDto | EducationDto | CertificationDto,
+  ) {
+    const [updated] = await this.db
+      .update(table)
+      .set(this.normalize(dto))
+      .where(eq(table.id, id))
+      .returning();
+    if (!updated) {
+      throw new NotFoundException();
+    }
+    this.revalidate.notify(['about']);
+    return updated;
+  }
+
+  async removeEntry(table: CvTable, id: string) {
+    const [deleted] = await this.db.delete(table).where(eq(table.id, id)).returning();
+    if (!deleted) {
+      throw new NotFoundException();
+    }
+    this.revalidate.notify(['about']);
+  }
+
+  /** Optional fields absent from the payload are cleared, not preserved. */
+  private normalize(dto: PositionDto | EducationDto | CertificationDto) {
+    return {
+      ...dto,
+      logoAssetId: dto.logoAssetId ?? null,
+      ...('endDate' in dto ? { endDate: dto.endDate ?? null } : {}),
+      ...('companyUrl' in dto ? { companyUrl: dto.companyUrl ?? null } : {}),
+      ...('expiresDate' in dto ? { expiresDate: dto.expiresDate ?? null } : {}),
+      ...('credentialUrl' in dto ? { credentialUrl: dto.credentialUrl ?? null } : {}),
+    };
+  }
+}

--- a/src/modules/about/dto/about.dto.ts
+++ b/src/modules/about/dto/about.dto.ts
@@ -1,0 +1,164 @@
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsUUID,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+export class UpdateAboutDto {
+  @IsString()
+  @MaxLength(100)
+  fullName: string;
+
+  @IsString()
+  profileMd: string;
+
+  @IsString()
+  @MaxLength(100)
+  location: string;
+
+  @IsString()
+  @MaxLength(200)
+  contactEmail: string;
+
+  @IsOptional()
+  @IsUUID()
+  avatarAssetId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  seoTitle?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  seoDescription?: string;
+}
+
+export class PositionDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(150)
+  company: string;
+
+  @IsOptional()
+  @IsUrl()
+  companyUrl?: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(150)
+  title: string;
+
+  @IsString()
+  @MaxLength(300)
+  description: string;
+
+  @IsString()
+  @MaxLength(100)
+  location: string;
+
+  @IsOptional()
+  @IsUUID()
+  logoAssetId?: string;
+
+  @IsDateString()
+  startDate: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  bullets: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @MaxLength(40, { each: true })
+  skills: string[];
+
+  @IsInt()
+  @Min(0)
+  sortOrder: number;
+}
+
+export class EducationDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  institution: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(150)
+  degree: string;
+
+  @IsString()
+  @MaxLength(150)
+  field: string;
+
+  @IsString()
+  @MaxLength(100)
+  location: string;
+
+  @IsOptional()
+  @IsUUID()
+  logoAssetId?: string;
+
+  @IsDateString()
+  startDate: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsString()
+  @MaxLength(500)
+  notes: string;
+
+  @IsInt()
+  @Min(0)
+  sortOrder: number;
+}
+
+export class CertificationDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(150)
+  name: string;
+
+  @IsString()
+  @MaxLength(150)
+  issuer: string;
+
+  @IsString()
+  @MaxLength(400)
+  description: string;
+
+  @IsOptional()
+  @IsUUID()
+  logoAssetId?: string;
+
+  @IsDateString()
+  issuedDate: string;
+
+  @IsOptional()
+  @IsDateString()
+  expiresDate?: string;
+
+  @IsOptional()
+  @IsUrl()
+  credentialUrl?: string;
+
+  @IsInt()
+  @Min(0)
+  sortOrder: number;
+}

--- a/src/modules/assets/assets-admin.controller.ts
+++ b/src/modules/assets/assets-admin.controller.ts
@@ -1,0 +1,85 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { AccessTokenGuard } from '../../common/guards/access-token.guard';
+import { AssetsService } from './assets.service';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const ALLOWED_MIME = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'image/avif',
+  'image/svg+xml',
+  'image/x-icon',
+]);
+
+class ListAssetsQueryDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  search?: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  per: number = 50;
+}
+
+class UploadAssetDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  alt?: string;
+}
+
+@Controller('admin/assets')
+@UseGuards(AccessTokenGuard)
+export class AssetsAdminController {
+  constructor(private readonly assets: AssetsService) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: MAX_FILE_SIZE } }))
+  upload(@UploadedFile() file: Express.Multer.File | undefined, @Body() dto: UploadAssetDto) {
+    if (!file) {
+      throw new BadRequestException('Missing file field');
+    }
+    if (!ALLOWED_MIME.has(file.mimetype)) {
+      throw new BadRequestException(`Unsupported content type: ${file.mimetype}`);
+    }
+    return this.assets.upload(file, dto.alt);
+  }
+
+  @Get()
+  list(@Query() query: ListAssetsQueryDto) {
+    return this.assets.list(query.search, query.page, query.per);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  async remove(@Param('id', ParseUUIDPipe) id: string) {
+    await this.assets.remove(id);
+  }
+}

--- a/src/modules/assets/assets.module.ts
+++ b/src/modules/assets/assets.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AssetsAdminController } from './assets-admin.controller';
+import { AssetsService } from './assets.service';
+import { S3Service } from './s3.service';
+
+@Module({
+  controllers: [AssetsAdminController],
+  providers: [AssetsService, S3Service],
+})
+export class AssetsModule {}

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -1,0 +1,72 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { desc, eq, ilike, sql } from 'drizzle-orm';
+import { Database, DRIZZLE } from '../../db/db.module';
+import { assets } from '../../db/schema';
+import { S3Service } from './s3.service';
+
+@Injectable()
+export class AssetsService {
+  private readonly publicUrl: string;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: Database,
+    private readonly s3: S3Service,
+    config: ConfigService,
+  ) {
+    this.publicUrl = config.getOrThrow<string>('S3_PUBLIC_URL');
+  }
+
+  private withUrl<T extends { s3Key: string }>(asset: T): T & { url: string } {
+    return { ...asset, url: `${this.publicUrl}/${asset.s3Key}` };
+  }
+
+  async upload(file: Express.Multer.File, alt: string | undefined) {
+    const key = await this.s3.upload(file.buffer, file.mimetype, file.originalname);
+
+    const [existing] = await this.db.select().from(assets).where(eq(assets.s3Key, key));
+    if (existing) {
+      // Same bytes + extension hash to the same key — reuse the row.
+      return this.withUrl(existing);
+    }
+
+    const [created] = await this.db
+      .insert(assets)
+      .values({
+        s3Key: key,
+        contentType: file.mimetype,
+        sizeBytes: file.size,
+        alt: alt ?? null,
+      })
+      .returning();
+    return this.withUrl(created);
+  }
+
+  async list(search: string | undefined, page: number, per: number) {
+    const where = search ? ilike(assets.s3Key, `%${search}%`) : undefined;
+
+    const [{ total }] = await this.db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(assets)
+      .where(where);
+
+    const items = await this.db
+      .select()
+      .from(assets)
+      .where(where)
+      .orderBy(desc(assets.createdAt))
+      .limit(per)
+      .offset((page - 1) * per);
+
+    return { items: items.map((a) => this.withUrl(a)), total, page, per };
+  }
+
+  async remove(id: string) {
+    const [asset] = await this.db.select().from(assets).where(eq(assets.id, id));
+    if (!asset) {
+      throw new NotFoundException();
+    }
+    await this.s3.delete(asset.s3Key);
+    await this.db.delete(assets).where(eq(assets.id, id));
+  }
+}

--- a/src/modules/assets/s3.service.ts
+++ b/src/modules/assets/s3.service.ts
@@ -1,0 +1,49 @@
+import { createHash } from 'crypto';
+import { extname } from 'path';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+@Injectable()
+export class S3Service {
+  private readonly client: S3Client;
+  private readonly bucket: string;
+
+  constructor(config: ConfigService) {
+    this.bucket = config.getOrThrow<string>('S3_BUCKET');
+    // S3_ENDPOINT is only set for S3-compatible storage (MinIO in dev); real AWS
+    // resolves its endpoint from the region and needs virtual-hosted style.
+    const endpoint = config.get<string>('S3_ENDPOINT');
+    this.client = new S3Client({
+      region: config.getOrThrow<string>('S3_REGION'),
+      credentials: {
+        accessKeyId: config.getOrThrow<string>('S3_ACCESS_KEY_ID'),
+        secretAccessKey: config.getOrThrow<string>('S3_SECRET_ACCESS_KEY'),
+      },
+      ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+    });
+  }
+
+  async upload(buffer: Buffer, contentType: string, originalName: string): Promise<string> {
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+    const hash = createHash('sha256').update(buffer).digest('hex').slice(0, 16);
+    const key = `uploads/${year}/${month}/${hash}${extname(originalName).toLowerCase()}`;
+
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }),
+    );
+    return key;
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+}

--- a/src/modules/config/config.controller.ts
+++ b/src/modules/config/config.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Inject,
+  InternalServerErrorException,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { Type } from 'class-transformer';
+import { IsArray, IsString, IsUrl, MaxLength, ValidateNested } from 'class-validator';
+import { eq } from 'drizzle-orm';
+import { AccessTokenGuard } from '../../common/guards/access-token.guard';
+import { Database, DRIZZLE } from '../../db/db.module';
+import { siteConfig } from '../../db/schema';
+import { RevalidateService } from '../revalidate/revalidate.service';
+
+class SocialLinkDto {
+  @IsString()
+  @MaxLength(50)
+  label: string;
+
+  @IsUrl()
+  url: string;
+}
+
+class UpdateSiteConfigDto {
+  @IsString()
+  @MaxLength(300)
+  heroTitle: string;
+
+  @IsString()
+  heroIntroMd: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SocialLinkDto)
+  socialLinks: SocialLinkDto[];
+
+  @IsString()
+  @MaxLength(200)
+  seoDefaultTitle: string;
+
+  @IsString()
+  @MaxLength(300)
+  seoDefaultDescription: string;
+
+  @IsString()
+  @MaxLength(200)
+  footerText: string;
+}
+
+@Controller()
+export class SiteConfigController {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: Database,
+    private readonly revalidate: RevalidateService,
+  ) {}
+
+  @Get('config')
+  async get() {
+    const [row] = await this.db.select().from(siteConfig).where(eq(siteConfig.id, 1));
+    if (!row) {
+      throw new InternalServerErrorException('site_config singleton row is missing');
+    }
+    return row;
+  }
+
+  @Put('admin/config')
+  @UseGuards(AccessTokenGuard)
+  async update(@Body() dto: UpdateSiteConfigDto) {
+    const [updated] = await this.db
+      .update(siteConfig)
+      .set({ ...dto, updatedAt: new Date() })
+      .where(eq(siteConfig.id, 1))
+      .returning();
+    this.revalidate.notify(['config']);
+    return updated;
+  }
+}

--- a/src/modules/config/config.module.ts
+++ b/src/modules/config/config.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { SiteConfigController } from './config.controller';
+
+@Module({
+  controllers: [SiteConfigController],
+})
+export class SiteConfigModule {}

--- a/test/content.e2e-spec.ts
+++ b/test/content.e2e-spec.ts
@@ -1,0 +1,189 @@
+import { eq } from 'drizzle-orm';
+import request from 'supertest';
+import { certifications, positions } from '../src/db/schema';
+import { createTestApp, TestApp } from './app.harness';
+import { createAuthedUser, deleteUser } from './auth-helper';
+
+const USER_EMAIL = 'e2e-content@test.local';
+const COMPANY = 'E2E Test Company';
+
+// 1x1 transparent PNG
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+describe('Assets, About, Config (e2e)', () => {
+  let ctx: TestApp;
+  let server: ReturnType<TestApp['app']['getHttpServer']>;
+  let token: string;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    server = ctx.app.getHttpServer();
+    token = await createAuthedUser(ctx, USER_EMAIL);
+    await ctx.db.delete(positions).where(eq(positions.company, COMPANY));
+  });
+
+  afterAll(async () => {
+    await ctx.db.delete(positions).where(eq(positions.company, COMPANY));
+    await deleteUser(ctx, USER_EMAIL);
+    await ctx.app.close();
+  });
+
+  describe('assets', () => {
+    let assetId: string;
+
+    it('uploads a PNG to object storage', async () => {
+      const res = await request(server)
+        .post('/api/admin/assets')
+        .set('Authorization', `Bearer ${token}`)
+        .field('alt', 'A test pixel')
+        .attach('file', PNG, { filename: 'pixel.png', contentType: 'image/png' })
+        .expect(201);
+      assetId = res.body.id;
+      expect(res.body.url).toMatch(/^http.*\/uploads\/\d{4}\/\d{2}\/[0-9a-f]{16}\.png$/);
+      expect(res.body.alt).toBe('A test pixel');
+
+      // The object must actually be retrievable from storage.
+      const stored = await fetch(res.body.url);
+      expect(stored.status).toBe(200);
+      expect(Buffer.from(await stored.arrayBuffer()).equals(PNG)).toBe(true);
+    });
+
+    it('rejects non-image uploads', async () => {
+      await request(server)
+        .post('/api/admin/assets')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', Buffer.from('#!/bin/sh\necho pwned'), {
+          filename: 'script.sh',
+          contentType: 'application/x-sh',
+        })
+        .expect(400);
+    });
+
+    it('lists and deletes assets', async () => {
+      const list = await request(server)
+        .get('/api/admin/assets')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(list.body.items.map((a: { id: string }) => a.id)).toContain(assetId);
+
+      await request(server)
+        .delete(`/api/admin/assets/${assetId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
+    });
+  });
+
+  describe('about', () => {
+    it('updates the profile and serves it publicly', async () => {
+      await request(server)
+        .put('/api/admin/about')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          fullName: 'E2E Person',
+          profileMd: 'A profile written by the e2e suite.',
+          location: 'Testville',
+          contactEmail: 'e2e@test.local',
+        })
+        .expect(200);
+
+      const pub = await request(server).get('/api/about').expect(200);
+      expect(pub.body.fullName).toBe('E2E Person');
+      expect(pub.body.avatarUrl).toBeNull();
+      expect(Array.isArray(pub.body.positions)).toBe(true);
+    });
+
+    it('runs a position through create/update/delete', async () => {
+      const base = {
+        company: COMPANY,
+        title: 'Engineer',
+        description: 'Doing e2e things.',
+        location: 'Remote',
+        startDate: '2024-01-01',
+        bullets: ['Did a thing', 'Did another thing'],
+        skills: ['testing'],
+        sortOrder: 99,
+      };
+      const created = await request(server)
+        .post('/api/admin/positions')
+        .set('Authorization', `Bearer ${token}`)
+        .send(base)
+        .expect(201);
+
+      const updated = await request(server)
+        .put(`/api/admin/positions/${created.body.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ ...base, title: 'Senior Engineer', endDate: '2026-01-01' })
+        .expect(200);
+      expect(updated.body.title).toBe('Senior Engineer');
+      expect(updated.body.endDate).toBe('2026-01-01');
+
+      const pub = await request(server).get('/api/about').expect(200);
+      const mine = pub.body.positions.find((p: { company: string }) => p.company === COMPANY);
+      expect(mine.title).toBe('Senior Engineer');
+      expect(mine.logoUrl).toBeNull();
+      expect(mine.logoAssetId).toBeUndefined();
+
+      await request(server)
+        .delete(`/api/admin/positions/${created.body.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
+    });
+
+    it('validates certification payloads', async () => {
+      await request(server)
+        .post('/api/admin/certifications')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: 'Broken',
+          issuer: 'Nobody',
+          description: '',
+          issuedDate: 'not-a-date',
+          sortOrder: 0,
+        })
+        .expect(400);
+      expect(
+        await ctx.db.select().from(certifications).where(eq(certifications.name, 'Broken')),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('site config', () => {
+    it('round-trips config through admin and public endpoints', async () => {
+      const payload = {
+        heroTitle: 'E2E hero title',
+        heroIntroMd: 'Intro from the e2e suite.',
+        socialLinks: [{ label: 'github', url: 'https://github.com/example' }],
+        seoDefaultTitle: 'E2E SEO title',
+        seoDefaultDescription: 'E2E SEO description',
+        footerText: '© e2e',
+      };
+      await request(server)
+        .put('/api/admin/config')
+        .set('Authorization', `Bearer ${token}`)
+        .send(payload)
+        .expect(200);
+
+      const pub = await request(server).get('/api/config').expect(200);
+      expect(pub.body.heroTitle).toBe(payload.heroTitle);
+      expect(pub.body.socialLinks).toEqual(payload.socialLinks);
+    });
+
+    it('rejects malformed social links', async () => {
+      await request(server)
+        .put('/api/admin/config')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          heroTitle: 'x',
+          heroIntroMd: '',
+          socialLinks: [{ label: 'bad', url: 'not-a-url' }],
+          seoDefaultTitle: '',
+          seoDefaultDescription: '',
+          footerText: '',
+        })
+        .expect(400);
+    });
+  });
+});


### PR DESCRIPTION
Fourth milestone, stacked on #42. This completes the API's functional surface.

## Assets
- `POST /api/admin/assets` — **multipart** upload (replaces the legacy 50MB base64-JSON scheme), 10MB cap, image mime whitelist, aws-sdk **v3**
- Content-hashed keys (`uploads/YYYY/MM/<sha256-prefix><ext>`) with `immutable` cache headers; duplicate bytes reuse the existing row
- MinIO in dev (`S3_ENDPOINT` + path-style), real S3 in prod

## About / CV
- Public `GET /api/about`: profile + positions + education + certifications in one payload, ordered by `sort_order` then date, logo/avatar asset ids resolved to public URLs (internal ids not exposed)
- Admin CRUD for all three CV entity types + profile PUT

## Site config
- Public `GET /api/config` (hero, intro, social links, SEO defaults, footer), admin PUT with nested validation
- Migration `0001` inserts the singleton rows so a fresh prod DB works without seeding

## Verified
`npm run test:e2e`: **34/34 green** — including an actual upload→fetch-from-MinIO byte-equality check and shell-script upload rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)