### PR TITLE
Rebuild A5: Docker image + deploy stack + hardened CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+coverage
+.git
+.github
+.claude
+.env
+.env.*
+!.env.example
+*.md
+test
+docker-compose.dev.yml
+deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: build-and-deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/personal-blog-api
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Resolve runner IP
+        id: ip
+        run: echo "ip=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
+
+      # SSH is closed by default; open it only for this runner, only for the
+      # duration of the deploy (revoked below even when the deploy fails).
+      - name: Open SSH to runner IP
+        run: |
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${{ secrets.EC2_SG_ID }}" \
+            --protocol tcp --port 22 \
+            --cidr "${{ steps.ip.outputs.ip }}/32"
+
+      - name: Deploy
+        run: |
+          install -m 700 -d ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
+            "${{ secrets.EC2_SSH_USER }}@${{ secrets.EC2_HOST }}" \
+            'cd /opt/blog \
+             && docker compose pull api \
+             && docker compose up -d api \
+             && docker compose exec -T api node dist/db/migrate.js \
+             && docker image prune -f'
+
+      - name: Revoke SSH access
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id "${{ secrets.EC2_SG_ID }}" \
+            --protocol tcp --port 22 \
+            --cidr "${{ steps.ip.outputs.ip }}/32"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# --- deps: install with lockfile ---------------------------------------------
+FROM node:22-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# --- build --------------------------------------------------------------------
+FROM deps AS build
+COPY tsconfig.json tsconfig.build.json nest-cli.json ./
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+# --- runtime ------------------------------------------------------------------
+FROM node:22-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# RDS TLS: trust the AWS RDS CA bundle so DATABASE_SSL=true verifies properly
+# (no rejectUnauthorized:false anywhere).
+ADD --chmod=444 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/rds-global-bundle.pem
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/rds-global-bundle.pem
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY drizzle ./drizzle
+
+USER node
+EXPOSE 4201
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s \
+  CMD curl -fsS http://localhost:4201/api/health || exit 1
+CMD ["node", "dist/main"]

--- a/README.md
+++ b/README.md
@@ -1,25 +1,64 @@
 # personal-blog-api
 
-API for [mikhailbahdashych.me](https://mikhailbahdashych.me) — NestJS 11, Drizzle ORM, PostgreSQL.
+API for [mikhailbahdashych.me](https://mikhailbahdashych.me) — NestJS 11 + Drizzle ORM + PostgreSQL.
 
-> Rebuild in progress. Full documentation (deployment, architecture) lands with the final infra PR.
+Part of a three-repo system:
+
+| Repo | Role |
+| --- | --- |
+| **personal-blog-api** (this) | Content API: posts, search, about/CV, site config, assets, auth |
+| `personal-blog-front` | Public blog — Next.js SSR |
+| `personal-blog-admin` | Admin panel — React SPA |
+
+## Architecture
+
+- **9 tables** (Drizzle schema in `src/db/schema.ts`, SQL migrations in `drizzle/`):
+  `posts` unifies articles and projects behind a `type` enum; `about` +
+  `positions`/`education`/`certifications` drive the CV page; `site_config`
+  drives the home page; `assets` are S3 objects referenced by id; `users`/`sessions`
+  hold the single admin account.
+- **Search**: stored generated `tsvector` (title^A, excerpt^B, plain_text^C) with a
+  GIN index; `websearch_to_tsquery` for phrases, prefix queries for typeahead;
+  `ts_headline` produces `<mark>`-highlighted titles and snippets.
+- **Auth**: bcrypt login → TOTP MFA (otplib) → 15-minute access JWT + 7-day
+  rotating refresh JWT in an `HttpOnly; Secure; SameSite=Strict` cookie scoped to
+  `/api/auth`. Replaying a rotated-out refresh token revokes the session.
+- **Revalidation**: every admin mutation fires a webhook to the frontend, which
+  invalidates the affected ISR cache tags.
+
+## Endpoints
+
+Public: `GET /api/posts`, `GET /api/posts/slugs`, `GET /api/posts/:slug`,
+`GET /api/search`, `GET /api/config`, `GET /api/about`, `GET /api/health`.
+
+Admin (`Authorization: Bearer <access token>`): CRUD under `/api/admin/posts`,
+`/api/admin/assets` (multipart), `/api/admin/positions|education|certifications`,
+`PUT /api/admin/about|config|password`. Auth flow under `/api/auth/*`.
 
 ## Development
 
 ```bash
-cp .env.example .env        # defaults work with the dev compose stack
+cp .env.example .env        # defaults match the dev compose stack
 npm install
 npm run dev:infra           # postgres :5433 + MinIO :9000/:9001
 npm run migrate
-npm run seed                # prints admin credentials
+npm run seed                # prints admin credentials (MFA enrolls on first login)
 npm run start:dev           # http://localhost:4201/api
 ```
 
-## Scripts
+Tests (need the dev stack): `npm run test:e2e` — 34 tests across auth, posts,
+search, assets/about/config.
 
 | Script | Purpose |
 | --- | --- |
-| `npm run migration:generate` | Generate SQL migration from `src/db/schema.ts` |
-| `npm run migrate` | Apply migrations from `drizzle/` |
-| `npm run seed` | Reset content tables + seed dev data (prints admin credentials) |
-| `npm run test:e2e` | End-to-end tests (needs the dev database) |
+| `npm run migration:generate` | Generate SQL migration from schema changes |
+| `npm run migrate` / `migrate:prod` | Apply migrations (tsx / built dist) |
+| `npm run seed` | Reset content tables + seed dev data |
+| `npm run lint` / `format` | ESLint / Prettier |
+
+## Deployment
+
+Docker image (multi-stage, distroless-ish `node:22-slim`, RDS CA bundle baked
+in) built by `.github/workflows/deploy.yml` → GHCR → SSH deploy to the EC2
+compose stack. Full runbook, including the legacy-system inventory and cutover
+steps: [`deploy/DEPLOYMENT.md`](deploy/DEPLOYMENT.md).

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -1,0 +1,114 @@
+# Deployment
+
+## 1. The legacy setup (documented before touching anything)
+
+Before the 2026 rebuild, production ran on EC2 (eu-central-1) like this:
+
+- **Three apps under pm2** on the host(s) referenced by the old workflow secrets
+  `FE_HOST_IP` / `API_HOST_IP` / `ADMIN_HOST_IP`, deployed by SSH-ing as
+  `deployer` and running build scripts that lived **on the server** (not in git).
+- Old security groups: `bahdashych-on-security-front|api|admin`. The old
+  workflows temporarily opened SSH — the API/admin ones to `0.0.0.0/0`.
+- nginx config also lived only on the server.
+- The admin panel was served by `ng serve` under pm2.
+- Database: RDS PostgreSQL (`POSTGRES_*` env), TLS with `rejectUnauthorized: false`.
+- The API had a `POST /api/control/trigger-deployment` endpoint that SSH-ed into
+  the host using `DEPLOYMENT_SSH_PRIVATE_KEY` — removed in the rebuild.
+
+**Do not delete** the old pm2 apps, server scripts, or keys until the new stack
+has run cleanly for a while: `pm2 stop all` is reversible, `pm2 delete` is not.
+The local key files (`deployer_key`, `personal-blog.pem`) and the untracked
+`.env.development` / `.env.production` stay where they are.
+
+## 2. New topology
+
+One EC2 instance runs Docker Compose (this directory) at `/opt/blog`:
+
+```
+                    ┌──────────────────────── EC2 ────────────────────────┐
+Internet ──443──▶ nginx ──▶ front (Next SSR :3000)   ──▶ api (:4201) ──▶ RDS
+                    │  ├──▶ api   (NestJS  :4201)    ◀── revalidate ──┘
+                    │  └──▶ admin (static  :80)              │
+                    └── certbot (renewals)                   └──▶ S3 (assets)
+```
+
+- `mikhailbahdashych.me` → front, `api.` → api, `admin.` → admin (DNS unchanged)
+- Images come from GHCR, built and pushed by each repo's GitHub Actions workflow
+- Deploys: workflow opens SSH **only to the runner IP**, runs
+  `docker compose pull <svc> && up -d <svc>`, revokes the rule (`if: always()`)
+
+## 3. One-time EC2 preparation
+
+```bash
+# as a sudo-capable user on the instance
+sudo apt-get update && sudo apt-get install -y docker.io docker-compose-plugin
+sudo usermod -aG docker $USER   # re-login afterwards
+
+sudo mkdir -p /opt/blog/nginx && sudo chown -R $USER /opt/blog
+# copy from this directory:
+#   docker-compose.prod.yml -> /opt/blog/docker-compose.yml
+#   nginx/blog.conf         -> /opt/blog/nginx/blog.conf
+# create /opt/blog/.env.api and /opt/blog/.env.front from env/*.example
+
+# GHCR access (images are private): create a GitHub PAT with read:packages
+docker login ghcr.io -u mikhailbahdashych
+```
+
+### First certificate issuance
+
+nginx can't serve 443 before certificates exist. Issue them once with a
+standalone certbot, then start the stack:
+
+```bash
+sudo docker run --rm -p 80:80 \
+  -v blog_letsencrypt:/etc/letsencrypt \
+  certbot/certbot certonly --standalone \
+  -d mikhailbahdashych.me -d api.mikhailbahdashych.me -d admin.mikhailbahdashych.me \
+  --email mikhail.bahdashych@gmail.com --agree-tos --no-eff-email
+```
+
+(The compose project name must make the volume resolve to `blog_letsencrypt`;
+start the stack from `/opt/blog` with `docker compose -p blog up -d`, or adjust.)
+
+### Database & storage
+
+- RDS: create database `personal_blog`; put the URL in `.env.api`
+  (`DATABASE_SSL=true` — the image trusts the RDS CA bundle).
+- Migrations run automatically on every deploy
+  (`docker compose exec api node dist/db/migrate.js`); the first boot creates
+  the whole schema. Singleton rows exist via migration `0001`.
+- Create the first admin user directly (one-time, from the EC2 host):
+  ```bash
+  docker compose exec api node -e "
+    const bcrypt = require('bcryptjs');
+    const { Pool } = require('pg');
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: true } : undefined });
+    const email = process.argv[1]; const password = process.argv[2];
+    pool.query('INSERT INTO users (email, password_hash) VALUES (\$1, \$2)', [email, bcrypt.hashSync(password, 12)])
+      .then(() => { console.log('created', email); process.exit(0); });
+  " 'you@example.com' 'a-long-unique-password'
+  ```
+  MFA enrollment happens on first admin login.
+- S3: the existing `bahdashych-on-security` bucket keeps working; the API needs
+  an IAM user limited to `s3:PutObject`/`s3:DeleteObject`/`s3:GetObject` on it.
+
+## 4. GitHub secrets (per repo)
+
+| Secret | Value |
+| --- | --- |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | IAM user allowed only `ec2:AuthorizeSecurityGroupIngress`/`RevokeSecurityGroupIngress` on the SG below |
+| `AWS_REGION` | `eu-central-1` |
+| `EC2_SG_ID` | security group of the instance |
+| `EC2_HOST` | instance public IP/DNS |
+| `EC2_SSH_USER` | `deployer` |
+| `EC2_SSH_KEY` | private key for that user |
+
+## 5. Cutover
+
+1. Prepare `/opt/blog` (§3), bring the stack up: `docker compose -p blog up -d`
+2. Verify all three vhosts respond over HTTPS; log into the admin, enroll MFA,
+   create content; check `/sitemap.xml`, `/rss.xml`, search
+3. `pm2 stop all` (leave the old apps stopped-but-present for rollback)
+4. Merge-triggered deploys now update one service at a time
+
+Rollback: `docker compose down` + `pm2 start all`.

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,50 @@
+# Production stack for mikhailbahdashych.me — runs on the EC2 host at /opt/blog.
+# Images are built by GitHub Actions and pulled from GHCR.
+# Env files (.env.api, .env.front) live next to this file and are NOT in git.
+services:
+  nginx:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./nginx/blog.conf:/etc/nginx/conf.d/default.conf:ro
+      - letsencrypt:/etc/letsencrypt:ro
+      - certbot-webroot:/var/www/certbot
+    depends_on:
+      - front
+      - api
+      - admin
+
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    entrypoint: /bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot --quiet; sleep 12h & wait $${!}; done'
+    volumes:
+      - letsencrypt:/etc/letsencrypt
+      - certbot-webroot:/var/www/certbot
+
+  front:
+    image: ghcr.io/mikhailbahdashych/personal-blog-front:latest
+    restart: unless-stopped
+    env_file: .env.front
+    expose:
+      - '3000'
+
+  api:
+    image: ghcr.io/mikhailbahdashych/personal-blog-api:latest
+    restart: unless-stopped
+    env_file: .env.api
+    expose:
+      - '4201'
+
+  admin:
+    image: ghcr.io/mikhailbahdashych/personal-blog-admin:latest
+    restart: unless-stopped
+    expose:
+      - '80'
+
+volumes:
+  letsencrypt:
+  certbot-webroot:

--- a/deploy/nginx/blog.conf
+++ b/deploy/nginx/blog.conf
@@ -1,0 +1,85 @@
+# Three vhosts: blog (Next SSR), api (NestJS), admin (static SPA).
+# TLS via Let's Encrypt (webroot); certificates issued once by hand, renewed by
+# the certbot container (see DEPLOYMENT.md).
+
+# --- HTTP: ACME challenges + redirect to HTTPS --------------------------------
+server {
+    listen 80;
+    server_name mikhailbahdashych.me api.mikhailbahdashych.me admin.mikhailbahdashych.me;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# --- Blog ---------------------------------------------------------------------
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name mikhailbahdashych.me;
+
+    ssl_certificate /etc/letsencrypt/live/mikhailbahdashych.me/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mikhailbahdashych.me/privkey.pem;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+    add_header X-Frame-Options DENY always;
+
+    location / {
+        proxy_pass http://front:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+# --- API ----------------------------------------------------------------------
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api.mikhailbahdashych.me;
+
+    ssl_certificate /etc/letsencrypt/live/mikhailbahdashych.me/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mikhailbahdashych.me/privkey.pem;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+
+    client_max_body_size 12m;  # multipart asset uploads (API caps files at 10MB)
+
+    location / {
+        proxy_pass http://api:4201;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+# --- Admin --------------------------------------------------------------------
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name admin.mikhailbahdashych.me;
+
+    ssl_certificate /etc/letsencrypt/live/mikhailbahdashych.me/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mikhailbahdashych.me/privkey.pem;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+
+    location / {
+        proxy_pass http://admin:80;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:infra:down": "docker compose -f docker-compose.dev.yml down",
     "migration:generate": "drizzle-kit generate",
     "migrate": "tsx src/db/migrate.ts",
+    "migrate:prod": "node dist/db/migrate.js",
     "seed": "tsx src/seed/seed.ts",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint \"src/**/*.ts\"",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["node_modules", "test", "dist", "src/seed", "src/db/migrate.ts"]
+  "exclude": ["node_modules", "test", "dist", "src/seed"]
 }


### PR DESCRIPTION
Final API milestone, stacked on #43. The API repo is now feature-complete for the rebuild.

## What this adds
- **Multi-stage Docker image** (`node:22-slim`): lockfile install → build → pruned runtime; RDS CA bundle baked in with `NODE_EXTRA_CA_CERTS` so `DATABASE_SSL=true` verifies properly (the legacy `rejectUnauthorized: false` is gone); non-root user + container healthcheck; migrations ship in `dist` and run on every deploy.
- **`deploy/`**: production compose (nginx TLS for the three vhosts + certbot renew loop + front/api/admin from GHCR), nginx config with HSTS/nosniff/frame-deny, env templates, and a full **DEPLOYMENT.md runbook** that first documents the existing pm2 setup (nothing gets destroyed — `pm2 stop`, not delete) and then the cutover.
- **CI**: buildx → GHCR (`sha` + `latest`, GHA layer cache) → SSH deploy. Port 22 opens **only to the runner's /32** and is revoked with `if: always()` — replacing the legacy workflow that opened the security group to `0.0.0.0/0` and ran build scripts that lived only on the server.

## Verified
- `docker build` + boot of the built image against the dev DB: `node dist/db/migrate.js` applies migrations, `/api/health` ok, public posts served ✔
- `docker compose -f deploy/docker-compose.prod.yml config` valid ✔
- Full e2e suite still **34/34**, lint clean ✔

## Merge order
#40 → #41 → #42 → #43 → this. After merging, add the GitHub secrets listed in DEPLOYMENT.md §4 before the first master push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)