### PR TITLE
Asset upload names, searchable, and a total order for every listing

### DIFF
--- a/drizzle/0002_tiny_wong.sql
+++ b/drizzle/0002_tiny_wong.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "assets" ADD COLUMN "filename" text DEFAULT '' NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,889 @@
+{
+  "id": "6d8dab48-6bbf-4210-a58c-8fde1d1c7342",
+  "prevId": "baa7a98c-c839-4591-938a-0f3a3c74e20a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.about": {
+      "name": "about",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar_asset_id": {
+          "name": "avatar_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_md": {
+          "name": "profile_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "about_avatar_asset_id_assets_id_fk": {
+          "name": "about_avatar_asset_id_assets_id_fk",
+          "tableFrom": "about",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "avatar_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "about_singleton": {
+          "name": "about_singleton",
+          "value": "\"about\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_s3_key_unique": {
+          "name": "assets_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certifications": {
+      "name": "certifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_date": {
+          "name": "issued_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_date": {
+          "name": "expires_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_url": {
+          "name": "credential_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certifications_logo_asset_id_assets_id_fk": {
+          "name": "certifications_logo_asset_id_assets_id_fk",
+          "tableFrom": "certifications",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education": {
+      "name": "education",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "education_logo_asset_id_assets_id_fk": {
+          "name": "education_logo_asset_id_assets_id_fk",
+          "tableFrom": "education",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_url": {
+          "name": "company_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bullets": {
+          "name": "bullets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "positions_logo_asset_id_assets_id_fk": {
+          "name": "positions_logo_asset_id_assets_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "plain_text": {
+          "name": "plain_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_time_min": {
+          "name": "reading_time_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "hero_asset_id": {
+          "name": "hero_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search": {
+          "name": "search",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', \"posts\".\"title\"), 'A') || setweight(to_tsvector('english', \"posts\".\"excerpt\"), 'B') || setweight(to_tsvector('english', \"posts\".\"plain_text\"), 'C')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_search_idx": {
+          "name": "posts_search_idx",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_listing_idx": {
+          "name": "posts_listing_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_hero_asset_id_assets_id_fk": {
+          "name": "posts_hero_asset_id_assets_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "hero_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_jti_hash": {
+          "name": "refresh_jti_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_user_id_unique": {
+          "name": "sessions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_config": {
+      "name": "site_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "hero_title": {
+          "name": "hero_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hero_intro_md": {
+          "name": "hero_intro_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "seo_default_title": {
+          "name": "seo_default_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seo_default_description": {
+          "name": "seo_default_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_text": {
+          "name": "footer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "site_config_singleton": {
+          "name": "site_config_singleton",
+          "value": "\"site_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "article",
+        "project"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1786201764266,
       "tag": "0001_seed_singletons",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786277266129,
+      "tag": "0002_tiny_wong",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,10 @@ export const sessions = pgTable('sessions', {
 export const assets = pgTable('assets', {
   id: uuid('id').primaryKey().defaultRandom(),
   s3Key: text('s3_key').notNull().unique(),
+  // The name the file was uploaded under. Kept for display and search only —
+  // the object key is derived from the content hash and MIME type, never from
+  // this, so a hostile filename cannot steer where the object lands.
+  filename: text('filename').notNull().default(''),
   contentType: text('content_type').notNull(),
   sizeBytes: integer('size_bytes').notNull(),
   alt: text('alt'),

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -83,7 +83,9 @@ export class AssetsService {
       .select()
       .from(assets)
       .where(where)
-      .orderBy(desc(assets.createdAt))
+      // Same reasoning as the post listings: a bulk upload shares a timestamp,
+      // and without a total order paging over it can drop rows.
+      .orderBy(desc(assets.createdAt), desc(assets.id))
       .limit(per)
       .offset((page - 1) * per);
 

--- a/src/modules/assets/assets.service.ts
+++ b/src/modules/assets/assets.service.ts
@@ -1,9 +1,28 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { desc, eq, ilike, sql } from 'drizzle-orm';
+import { desc, eq, ilike, or, sql, SQL } from 'drizzle-orm';
 import { Database, DRIZZLE } from '@db/db.module';
 import { assets } from '@db/schema';
 import { S3Service } from './s3.service';
+
+/**
+ * Display-only, so this just has to be sane text: no control characters, no
+ * path, bounded length.
+ *
+ * Multipart filenames arrive latin1-decoded, which turns a UTF-8 name like
+ * 'ünïcode.png' into 'Ã¼nÃ¯code.png'. Reading those bytes back as UTF-8 undoes
+ * it; a name that was genuinely latin1 decodes to U+FFFD, so keep the original.
+ */
+function sanitizeFilename(originalName: string): string {
+  const reinterpreted = Buffer.from(originalName, 'latin1').toString('utf8');
+  const decoded = reinterpreted.includes('�') ? originalName : reinterpreted;
+  const base = decoded.split(/[/\\]/).pop() ?? '';
+  return Array.from(base)
+    .filter((char) => char.codePointAt(0)! > 0x1f)
+    .join('')
+    .trim()
+    .slice(0, 200);
+}
 
 @Injectable()
 export class AssetsService {
@@ -34,6 +53,7 @@ export class AssetsService {
       .insert(assets)
       .values({
         s3Key: key,
+        filename: sanitizeFilename(file.originalname),
         contentType: file.mimetype,
         sizeBytes: file.size,
         alt: alt ?? null,
@@ -43,7 +63,16 @@ export class AssetsService {
   }
 
   async list(search: string | undefined, page: number, per: number) {
-    const where = search ? ilike(assets.s3Key, `%${search}%`) : undefined;
+    // Match what the admin actually shows: the upload name and alt text. The
+    // key is a content hash, so searching it alone was never useful.
+    const term = search?.trim();
+    const where: SQL | undefined = term
+      ? or(
+          ilike(assets.filename, `%${term}%`),
+          ilike(assets.alt, `%${term}%`),
+          ilike(assets.s3Key, `%${term}%`),
+        )
+      : undefined;
 
     const [{ total }] = await this.db
       .select({ total: sql<number>`count(*)::int` })

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -58,7 +58,10 @@ export class PostsService {
       .from(posts)
       .leftJoin(assets, eq(posts.heroAssetId, assets.id))
       .where(where)
-      .orderBy(desc(posts.publishedAt))
+      // publishedAt alone is not a total order: publish two posts in the same
+      // instant and LIMIT/OFFSET can show one twice and another not at all.
+      // The unique id breaks every tie deterministically.
+      .orderBy(desc(posts.publishedAt), desc(posts.id))
       .limit(query.per)
       .offset((query.page - 1) * query.per);
 
@@ -103,7 +106,7 @@ export class PostsService {
       .select({ slug: posts.slug, type: posts.type, updatedAt: posts.updatedAt })
       .from(posts)
       .where(eq(posts.published, true))
-      .orderBy(desc(posts.publishedAt));
+      .orderBy(desc(posts.publishedAt), desc(posts.id));
   }
 
   // --- admin ----------------------------------------------------------------
@@ -136,7 +139,7 @@ export class PostsService {
       })
       .from(posts)
       .where(where)
-      .orderBy(desc(posts.updatedAt))
+      .orderBy(desc(posts.updatedAt), desc(posts.id))
       .limit(query.per)
       .offset((query.page - 1) * query.per);
 

--- a/test/content.e2e-spec.ts
+++ b/test/content.e2e-spec.ts
@@ -62,6 +62,52 @@ describe('Assets, About, Config (e2e)', () => {
         .expect(400);
     });
 
+    it('keeps the upload name for display, without letting it steer the key', async () => {
+      const res = await request(server)
+        .post('/api/admin/assets')
+        .set('Authorization', `Bearer ${token}`)
+        .field('alt', 'traversal probe')
+        .attach('file', Buffer.concat([PNG, Buffer.from([1])]), {
+          filename: '../../etc/Ünicode Name.png',
+          contentType: 'image/png',
+        })
+        .expect(201);
+
+      // Path stripped, UTF-8 preserved, extension still derived from the type.
+      expect(res.body.filename).toBe('Ünicode Name.png');
+      expect(res.body.s3Key).toMatch(/^uploads\/\d{4}\/\d{2}\/[0-9a-f]{16}\.png$/);
+
+      // ILIKE is a plain substring match, so search an ASCII run of the name —
+      // 'Ünicode' lowercases to 'ünicode' and would not match 'unicode'.
+      const byName = await request(server)
+        .get('/api/admin/assets')
+        .query({ search: 'nicode Name' })
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(byName.body.items.map((a: { id: string }) => a.id)).toContain(res.body.id);
+
+      const byAlt = await request(server)
+        .get('/api/admin/assets')
+        .query({ search: 'traversal' })
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(byAlt.body.items.map((a: { id: string }) => a.id)).toContain(res.body.id);
+
+      const page = await request(server)
+        .get('/api/admin/assets')
+        .query({ page: 1, per: 1 })
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(page.body.items).toHaveLength(1);
+      expect(page.body.per).toBe(1);
+      expect(page.body.total).toBeGreaterThan(1);
+
+      await request(server)
+        .delete(`/api/admin/assets/${res.body.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
+    });
+
     it('lists and deletes assets', async () => {
       const list = await request(server)
         .get('/api/admin/assets')


### PR DESCRIPTION
Groundwork for the admin's assets page (`personal-blog-admin#48`).

## Upload names

The `assets` table stored only the content-hash key, so the admin had nothing to display and search matched a hash — never what you type. Adds a `filename` column (migration `0002`), populated on upload and searched alongside `alt`.

**Display metadata only.** The object key is still `uploads/<year>/<month>/<sha256-16>.<ext>`, derived from the content hash and validated MIME type — a hostile name cannot steer where the object lands. Paths are stripped to the basename, length bounded at 200.

A bug found while testing: multipart filenames arrive latin1-decoded, so `ünïcode—name.png` was stored as `Ã¼nÃ¯codeâname.png`. Reading the bytes back as UTF-8 restores it; a name that genuinely was latin1 decodes to `U+FFFD` and keeps the original.

| Input | Stored |
| --- | --- |
| `Architecture Diagram v2.png` | `Architecture Diagram v2.png` |
| `../../etc/passwd.png` | `passwd.png` |
| `ünïcode—name.png` | `ünïcode—name.png` |
| 300-char name | truncated to 200 |

## A total order for every paginated listing

`publishedAt` — and `createdAt`, and `updatedAt` — are not total orders. Publish or upload several things in the same instant and rows tie; `LIMIT`/`OFFSET` over a tied ordering may return a row on two pages or on **neither**, so an item can simply never appear while paging.

Adding the unique id as a tiebreaker makes it deterministic, on the public post listing, the slug feed, the admin post listing and the asset listing.

Covered by a new e2e test — 35/35 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)