### PR TITLE
Add a maintenance-mode switch

### DIFF
--- a/drizzle/0004_wise_rachel_grey.sql
+++ b/drizzle/0004_wise_rachel_grey.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "site_config" ADD COLUMN "maintenance" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,908 @@
+{
+  "id": "fab31745-4155-4c6d-9993-1adfec1c6b85",
+  "prevId": "d6f8fe2b-c2cc-4b18-a2b9-642eb368cfb1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.about": {
+      "name": "about",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "avatar_asset_id": {
+          "name": "avatar_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_md": {
+          "name": "profile_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "about_avatar_asset_id_assets_id_fk": {
+          "name": "about_avatar_asset_id_assets_id_fk",
+          "tableFrom": "about",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "avatar_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "about_singleton": {
+          "name": "about_singleton",
+          "value": "\"about\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_s3_key_unique": {
+          "name": "assets_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certifications": {
+      "name": "certifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_date": {
+          "name": "issued_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_date": {
+          "name": "expires_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_url": {
+          "name": "credential_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certifications_logo_asset_id_assets_id_fk": {
+          "name": "certifications_logo_asset_id_assets_id_fk",
+          "tableFrom": "certifications",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education": {
+      "name": "education",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "education_logo_asset_id_assets_id_fk": {
+          "name": "education_logo_asset_id_assets_id_fk",
+          "tableFrom": "education",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.positions": {
+      "name": "positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_url": {
+          "name": "company_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_asset_id": {
+          "name": "logo_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bullets": {
+          "name": "bullets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "positions_logo_asset_id_assets_id_fk": {
+          "name": "positions_logo_asset_id_assets_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "logo_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "plain_text": {
+          "name": "plain_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_time_min": {
+          "name": "reading_time_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "hero_asset_id": {
+          "name": "hero_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search": {
+          "name": "search",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', \"posts\".\"title\"), 'A') || setweight(to_tsvector('english', \"posts\".\"excerpt\"), 'B') || setweight(to_tsvector('english', \"posts\".\"plain_text\"), 'C')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_search_idx": {
+          "name": "posts_search_idx",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "posts_listing_idx": {
+          "name": "posts_listing_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_hero_asset_id_assets_id_fk": {
+          "name": "posts_hero_asset_id_assets_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "hero_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_jti_hash": {
+          "name": "refresh_jti_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_jti_hash": {
+          "name": "previous_jti_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_user_id_unique": {
+          "name": "sessions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_config": {
+      "name": "site_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "hero_title": {
+          "name": "hero_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hero_intro_md": {
+          "name": "hero_intro_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "seo_default_title": {
+          "name": "seo_default_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seo_default_description": {
+          "name": "seo_default_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_text": {
+          "name": "footer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "maintenance": {
+          "name": "maintenance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "site_config_singleton": {
+          "name": "site_config_singleton",
+          "value": "\"site_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "article",
+        "project"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786292761538,
       "tag": "0003_safe_vengeance",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786469750193,
+      "tag": "0004_wise_rachel_grey",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -113,6 +113,8 @@ export const siteConfig = pgTable(
     seoDefaultTitle: text('seo_default_title').notNull().default(''),
     seoDefaultDescription: text('seo_default_description').notNull().default(''),
     footerText: text('footer_text').notNull().default(''),
+    // Deploy-time switch, not content: served via /maintenance, never /config.
+    maintenance: boolean('maintenance').notNull().default(false),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [check('site_config_singleton', sql`${t.id} = 1`)],

--- a/src/modules/config/config.controller.ts
+++ b/src/modules/config/config.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/swagger';
 import { AccessTokenGuard } from '@common/guards/access-token.guard';
 import { SiteConfigService } from './config.service';
-import { UpdateSiteConfigDto } from './dto/config.dto';
+import { UpdateMaintenanceDto, UpdateSiteConfigDto } from './dto/config.dto';
 
 @ApiTags('Config')
 @Controller()
@@ -20,6 +20,22 @@ export class SiteConfigController {
   @ApiOkResponse({ description: 'Hero, intro, social links, SEO defaults, footer.' })
   get() {
     return this.config.get();
+  }
+
+  @Get('maintenance')
+  @ApiOperation({ summary: 'Maintenance-mode flag, read by the frontend middleware' })
+  @ApiOkResponse({ description: '{ enabled: boolean }' })
+  getMaintenance() {
+    return this.config.getMaintenance();
+  }
+
+  @Put('admin/maintenance')
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '[admin] Toggle maintenance mode' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid access token.' })
+  setMaintenance(@Body() dto: UpdateMaintenanceDto) {
+    return this.config.setMaintenance(dto.enabled);
   }
 
   @Put('admin/config')

--- a/src/modules/config/config.service.ts
+++ b/src/modules/config/config.service.ts
@@ -5,6 +5,22 @@ import { siteConfig } from '@db/schema';
 import { RevalidateService } from '@modules/revalidate/revalidate.service';
 import { UpdateSiteConfigDto } from './dto/config.dto';
 
+/**
+ * The public config payload, spelled out so the maintenance flag stays off it:
+ * /config feeds the admin settings form and the frontend cache, while the flag
+ * is deploy state with its own endpoints and no caching.
+ */
+const PUBLIC_COLUMNS = {
+  id: siteConfig.id,
+  heroTitle: siteConfig.heroTitle,
+  heroIntroMd: siteConfig.heroIntroMd,
+  socialLinks: siteConfig.socialLinks,
+  seoDefaultTitle: siteConfig.seoDefaultTitle,
+  seoDefaultDescription: siteConfig.seoDefaultDescription,
+  footerText: siteConfig.footerText,
+  updatedAt: siteConfig.updatedAt,
+};
+
 @Injectable()
 export class SiteConfigService {
   constructor(
@@ -13,7 +29,7 @@ export class SiteConfigService {
   ) {}
 
   async get() {
-    const [row] = await this.db.select().from(siteConfig).where(eq(siteConfig.id, 1));
+    const [row] = await this.db.select(PUBLIC_COLUMNS).from(siteConfig).where(eq(siteConfig.id, 1));
     if (!row) {
       throw new InternalServerErrorException('site_config singleton row is missing');
     }
@@ -25,8 +41,32 @@ export class SiteConfigService {
       .update(siteConfig)
       .set({ ...dto, updatedAt: new Date() })
       .where(eq(siteConfig.id, 1))
-      .returning();
+      .returning(PUBLIC_COLUMNS);
     this.revalidate.notify(['config']);
     return updated;
+  }
+
+  async getMaintenance() {
+    const [row] = await this.db
+      .select({ enabled: siteConfig.maintenance })
+      .from(siteConfig)
+      .where(eq(siteConfig.id, 1));
+    if (!row) {
+      throw new InternalServerErrorException('site_config singleton row is missing');
+    }
+    return row;
+  }
+
+  /**
+   * Flips the switch without touching updatedAt (it tracks content edits) and
+   * without revalidation — the frontend middleware reads the flag uncached.
+   */
+  async setMaintenance(enabled: boolean) {
+    const [row] = await this.db
+      .update(siteConfig)
+      .set({ maintenance: enabled })
+      .where(eq(siteConfig.id, 1))
+      .returning({ enabled: siteConfig.maintenance });
+    return row;
   }
 }

--- a/src/modules/config/dto/config.dto.ts
+++ b/src/modules/config/dto/config.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsString, IsUrl, MaxLength, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsString, IsUrl, MaxLength, ValidateNested } from 'class-validator';
+
+export class UpdateMaintenanceDto {
+  @ApiProperty({ description: 'true sends the public site to /maintenance' })
+  @IsBoolean()
+  enabled: boolean;
+}
 
 export class SocialLinkDto {
   @ApiProperty({ example: 'github' })

--- a/test/content.e2e-spec.ts
+++ b/test/content.e2e-spec.ts
@@ -202,6 +202,24 @@ describe('Assets, About, Config (e2e)', () => {
   });
 
   describe('site config', () => {
+    // The suite runs against the dev database; put whatever config was there
+    // back so a test run never leaves "E2E hero title" on the real site.
+    let original: Record<string, unknown>;
+
+    beforeAll(async () => {
+      const res = await request(server).get('/api/config').expect(200);
+      const { id: _id, updatedAt: _updatedAt, ...rest } = res.body;
+      original = rest;
+    });
+
+    afterAll(async () => {
+      await request(server)
+        .put('/api/admin/config')
+        .set('Authorization', `Bearer ${token}`)
+        .send(original)
+        .expect(200);
+    });
+
     it('round-trips config through admin and public endpoints', async () => {
       const payload = {
         heroTitle: 'E2E hero title',
@@ -234,6 +252,50 @@ describe('Assets, About, Config (e2e)', () => {
           seoDefaultDescription: '',
           footerText: '',
         })
+        .expect(400);
+    });
+  });
+
+  describe('maintenance mode', () => {
+    afterAll(async () => {
+      // Never leave the site in maintenance because a test run died mid-way.
+      await request(server)
+        .put('/api/admin/maintenance')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ enabled: false })
+        .expect(200);
+    });
+
+    it('toggles through the admin endpoint and reads back publicly', async () => {
+      const on = await request(server)
+        .put('/api/admin/maintenance')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ enabled: true })
+        .expect(200);
+      expect(on.body).toEqual({ enabled: true });
+
+      const pub = await request(server).get('/api/maintenance').expect(200);
+      expect(pub.body).toEqual({ enabled: true });
+
+      const off = await request(server)
+        .put('/api/admin/maintenance')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ enabled: false })
+        .expect(200);
+      expect(off.body).toEqual({ enabled: false });
+    });
+
+    it('never leaks the flag into the public config payload', async () => {
+      const pub = await request(server).get('/api/config').expect(200);
+      expect(pub.body).not.toHaveProperty('maintenance');
+    });
+
+    it('requires auth and a boolean', async () => {
+      await request(server).put('/api/admin/maintenance').send({ enabled: true }).expect(401);
+      await request(server)
+        .put('/api/admin/maintenance')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ enabled: 'yes' })
         .expect(400);
     });
   });


### PR DESCRIPTION
## What

A deploy-time switch: `maintenance` boolean on the `site_config` singleton (migration 0004), exposed as

- `GET /api/maintenance` → `{ enabled }` — public, read by the frontend middleware on every page request
- `PUT /api/admin/maintenance` — guarded, `{ enabled: boolean }`

Deliberate boundaries: the flag never appears in the public `/config` payload (so it cannot round-trip through the admin settings form), and toggling does not bump `updatedAt` or fire content revalidation — the middleware reads it uncached.

## Test hygiene fix

The site-config e2e tests used to leave "E2E hero title" in the dev database after every run. They now snapshot the config in `beforeAll` and restore it in `afterAll`, and the new maintenance tests always reset the flag to off.

## Testing

39/39 e2e (3 new: toggle round-trip, no leak into `/config`, auth + validation), eslint + tsc clean.

**Merge order:** merge this before personal-blog-front's maintenance PR — the frontend middleware treats a missing `/maintenance` endpoint as "maintenance on".

🤖 Generated with [Claude Code](https://claude.com/claude-code)